### PR TITLE
feat: 예약 가능 시간 조회

### DIFF
--- a/src/main/java/org/example/studiopick/application/reservation/ReservationService.java
+++ b/src/main/java/org/example/studiopick/application/reservation/ReservationService.java
@@ -1,6 +1,7 @@
 package org.example.studiopick.application.reservation;
 
 import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.reservation.dto.AvailableTimesResponse;
 import org.example.studiopick.application.reservation.dto.ReservationCreateCommand;
 import org.example.studiopick.application.reservation.dto.ReservationResponse;
 import org.example.studiopick.domain.common.enums.ReservationStatus;
@@ -8,11 +9,19 @@ import org.example.studiopick.domain.reservation.Reservation;
 import org.example.studiopick.domain.reservation.ReservationDomainService;
 import org.example.studiopick.domain.reservation.ReservationRepository;
 import org.example.studiopick.domain.studio.Studio;
+import org.example.studiopick.domain.studio.StudioOperatingHoursRepository;
 import org.example.studiopick.domain.studio.StudioRepository;
 import org.example.studiopick.domain.user.User;
 import org.example.studiopick.domain.user.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 // ReservationService.java
 @Service
@@ -22,9 +31,10 @@ public class ReservationService {
   private final ReservationRepository reservationRepository;
   private final StudioRepository studioRepository;
   private final UserRepository userRepository;
+  private final StudioOperatingHoursRepository studioOperatingHoursRepository;
 
   @Transactional
-  public ReservationResponse create(ReservationCreateCommand command) {
+  public ReservationResponse create(Long studioId, ReservationCreateCommand command) {
     reservationDomainService.validateOverlapping(
         command.studioId(),
         command.reservationDate(),
@@ -56,6 +66,40 @@ public class ReservationService {
         saved.getId(),
         saved.getTotalAmount(),
         saved.getStatus()
+    );
+  }
+
+  public AvailableTimesResponse getAvailableTimes(Long studioId, LocalDate date) {
+    // 1. 해당 날짜 예약 조회
+    List<Reservation> reservations = reservationRepository.findByStudioIdAndReservationDateAndStatus(
+        studioId, date, ReservationStatus.CONFIRMED
+    );
+
+    // 2. 예약된 시간 리스트
+    List<String> bookedTimes = reservations.stream()
+        .sorted(Comparator.comparing(Reservation::getStartTime))
+        .map(r -> r.getStartTime().toString())
+        .toList();
+
+    // 3. 예: 오전 9시 ~ 오후 6시 기준 가용 시간 생성
+    LocalTime start = LocalTime.of(9, 0);
+    LocalTime end = LocalTime.of(18, 0);
+
+    List<String> allTimes = new ArrayList<>();
+    LocalTime cursor = start;
+    while (cursor.isBefore(end)) {
+      allTimes.add(cursor.toString());
+      cursor = cursor.plusHours(1);
+    }
+
+    // 4. 예약된 시간을 제외한 가용 시간
+    List<String> availableTimes = allTimes.stream()
+        .filter(t -> !bookedTimes.contains(t))
+        .collect(Collectors.toList());
+
+    return new AvailableTimesResponse(
+        availableTimes,
+        bookedTimes
     );
   }
 }

--- a/src/main/java/org/example/studiopick/application/reservation/dto/AvailableTimesResponse.java
+++ b/src/main/java/org/example/studiopick/application/reservation/dto/AvailableTimesResponse.java
@@ -1,0 +1,8 @@
+package org.example.studiopick.application.reservation.dto;
+
+import java.util.List;
+
+public record AvailableTimesResponse(
+    List<String> availableTimes,
+    List<String> bookedTimes
+){}

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -6,12 +6,12 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface ReservationRepository {
   boolean existsOverlappingReservation(Long studioId, LocalDate date, ReservationStatus status, LocalTime start, LocalTime end);
 
   Reservation save(Reservation reservation);
-
-  Optional<Reservation> findById(Long id);
+  List<Reservation> findByStudioIdAndReservationDateAndStatus(Long studioId, LocalDate reservationDate, ReservationStatus reservationStatus);
 }

--- a/src/main/java/org/example/studiopick/domain/studio/StudioOperatingHoursRepository.java
+++ b/src/main/java/org/example/studiopick/domain/studio/StudioOperatingHoursRepository.java
@@ -1,0 +1,9 @@
+package org.example.studiopick.domain.studio;
+
+import java.time.DayOfWeek;
+import java.util.Optional;
+
+public interface StudioOperatingHoursRepository {
+
+  Optional<StudioOperatingHours> findByStudioIdAndWeekday(Long studioId, DayOfWeek dayOfWeek);
+}

--- a/src/main/java/org/example/studiopick/infrastructure/studio/JpaStudioOperatingHoursRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/studio/JpaStudioOperatingHoursRepository.java
@@ -1,0 +1,8 @@
+package org.example.studiopick.infrastructure.studio;
+
+import org.example.studiopick.domain.studio.StudioOperatingHours;
+import org.example.studiopick.domain.studio.StudioOperatingHoursRepository;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaStudioOperatingHoursRepository extends JpaRepository<StudioOperatingHours, Long> , StudioOperatingHoursRepository {
+}

--- a/src/main/java/org/example/studiopick/web/ReservationController.java
+++ b/src/main/java/org/example/studiopick/web/ReservationController.java
@@ -2,34 +2,52 @@ package org.example.studiopick.web;
 
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.application.reservation.ReservationService;
+import org.example.studiopick.application.reservation.dto.AvailableTimesResponse;
 import org.example.studiopick.application.reservation.dto.ReservationCreateCommand;
 import org.example.studiopick.application.reservation.dto.ReservationResponse;
 import org.example.studiopick.common.dto.ApiResponse;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
-@RequestMapping("/api/reservations")
+@RequestMapping("/api/studios/{studioId}/reservations")
 @RequiredArgsConstructor
 public class ReservationController {
+
   private final ReservationService reservationService;
 
+  /**
+   * 예약 생성
+   */
   @PostMapping
   public ResponseEntity<ApiResponse<ReservationResponse>> createReservation(
-      @RequestBody ReservationCreateCommand command) {
-
-    ReservationResponse response = reservationService.create(command);
+      @PathVariable Long studioId,
+      @RequestBody ReservationCreateCommand command
+  ) {
+    ReservationResponse response = reservationService.create(studioId, command);
 
     ApiResponse<ReservationResponse> apiResponse = new ApiResponse<>(
         true,
         response,
-        "예약이 신청되었습니다"
+        "예약이 신청되었습니다."
     );
 
     return ResponseEntity.status(HttpStatus.CREATED).body(apiResponse);
+  }
+
+  /**
+   * 예약 가능 시간 조회
+   */
+  @GetMapping("/available-times")
+  public ApiResponse<AvailableTimesResponse> getAvailableTimes(
+      @PathVariable Long studioId,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+  ) {
+    AvailableTimesResponse response = reservationService.getAvailableTimes(studioId, date);
+    return new ApiResponse<>(true, response, null);
   }
 }


### PR DESCRIPTION
**📝 변경 사항**

- GET /api/studios/{studioId}/reservations/available-times 엔드포인트 구현
- ReservationController에서 예약 가능 시간 조회 요청 처리
- ReservationService에서 가용 시간 계산 로직 구현
- AvailableTimesResponse DTO 추가
- ReservationRepository에 날짜별 예약 조회 메서드 추가

**🎯 주요 기능**

- 특정 스튜디오의 특정 날짜 예약 가능 시간 조회
- 기존 CONFIRMED 예약을 제외한 가용 시간 계산
- 오전 9시~오후 6시 운영시간 기준 1시간 단위 시간 슬롯 제공
- 예약된 시간과 가능한 시간을 구분하여 응답

**🏗️ 구현 내용**

> Controller

- ReservationController.getAvailableTimes() 메서드 추가
- Path Variable로 studioId 받기
- Query Parameter로 date 받기 (@DateTimeFormat 적용)
- ApiResponse 래퍼로 일관된 응답 형식 제공

> Service

- ReservationService.getAvailableTimes() 메서드 구현
- 해당 날짜의 CONFIRMED 예약 조회
- 오전 9시~오후 6시 전체 시간 슬롯 생성
- 예약된 시간을 제외한 가용 시간 필터링

> Repository

- ReservationRepository.findByStudioIdAndReservationDateAndStatus() 메서드 추가
- 스튜디오, 날짜, 예약상태 기준 예약 목록 조회

> DTO

- AvailableTimesResponse.java 추가
- availableTimes: 예약 가능한 시간 목록
- bookedTimes: 이미 예약된 시간 목록


**✅ 비즈니스 로직**

- 운영시간 고정: 오전 9시~오후 6시 (09:00-18:00)
- 시간 단위: 1시간 단위 시간 슬롯
- 예약 상태 필터링: CONFIRMED 상태의 예약만 제외
- 시간 정렬: 예약된 시간은 시작시간 기준 오름차순 정렬
- 중복 제거: 예약된 시간을 전체 시간에서 제외하여 가용 시간 계산

**🔄 관련 파일**

- ReservationController.java - 예약 가능 시간 조회 엔드포인트
- ReservationService.java - 가용 시간 계산 비즈니스 로직
- ReservationRepository.java - 날짜별 예약 조회 메서드
- AvailableTimesResponse.java - 예약 가능 시간 응답 DTO
-


📌 **참고사항**

- 현재는 운영시간이 09:00-18:00으로 하드코딩됨 (추후 스튜디오별 운영시간 적용 필요)
- CONFIRMED 상태의 예약만 제외 (PENDING 상태는 가용 시간으로 처리)
- 1시간 단위 시간 슬롯만 지원
- StudioOperatingHoursRepository는 의존성만 추가되고 실제 사용은 안됨
