### PR TITLE
feat:예약 동시성 처리

### DIFF
--- a/src/main/java/org/example/studiopick/application/reservation/ReservationService.java
+++ b/src/main/java/org/example/studiopick/application/reservation/ReservationService.java
@@ -35,6 +35,11 @@ public class ReservationService {
 
   @Transactional
   public ReservationResponse create(Long studioId, ReservationCreateCommand command) {
+
+    // 스튜디오 동시성 처리를 위한 락 흭득
+    Studio studio = studioRepository.findByIdWithLock(studioId)
+        .orElseThrow(() -> new IllegalArgumentException("해당 Studio id를 찾을 수 없습니다."));
+
     reservationDomainService.validateOverlapping(
         command.studioId(),
         command.reservationDate(),
@@ -42,9 +47,6 @@ public class ReservationService {
         command.startTime(),
         command.endTime()
     );
-
-    Studio studio = studioRepository.findById(command.studioId())
-        .orElseThrow(() -> new IllegalArgumentException("해당 Studio id를 찾을 수 없습니다."));
 
     User user = userRepository.findById(command.userId())
         .orElseThrow(() -> new IllegalArgumentException("해당 User id를 찾을 수 없습니다."));
@@ -58,6 +60,7 @@ public class ReservationService {
         .endTime(command.endTime())
         .status(ReservationStatus.CONFIRMED)
         .peopleCount(command.peopleCount())
+        .totalAmount(command.totalAmount())
         .build();
 
     Reservation saved = reservationRepository.save(reservation);

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -13,5 +13,6 @@ public interface ReservationRepository {
   boolean existsOverlappingReservation(Long studioId, LocalDate date, ReservationStatus status, LocalTime start, LocalTime end);
 
   Reservation save(Reservation reservation);
+
   List<Reservation> findByStudioIdAndReservationDateAndStatus(Long studioId, LocalDate reservationDate, ReservationStatus reservationStatus);
 }

--- a/src/main/java/org/example/studiopick/domain/studio/StudioOperatingHoursRepository.java
+++ b/src/main/java/org/example/studiopick/domain/studio/StudioOperatingHoursRepository.java
@@ -5,5 +5,5 @@ import java.util.Optional;
 
 public interface StudioOperatingHoursRepository {
 
-  Optional<StudioOperatingHours> findByStudioIdAndWeekday(Long studioId, DayOfWeek dayOfWeek);
+//  Optional<StudioOperatingHours> findByStudioIdAndWeekday(Long studioId, DayOfWeek dayOfWeek);
 }

--- a/src/main/java/org/example/studiopick/domain/studio/StudioRepository.java
+++ b/src/main/java/org/example/studiopick/domain/studio/StudioRepository.java
@@ -1,9 +1,10 @@
 package org.example.studiopick.domain.studio;
 
-import org.example.studiopick.domain.reservation.Reservation;
-
+import org.springframework.data.repository.query.Param;
 import java.util.Optional;
 
 public interface StudioRepository {
   public Optional<Studio> findById(Long id);
+
+  public Optional<Studio> findByIdWithLock(@Param("id") Long id);
 }

--- a/src/main/java/org/example/studiopick/infrastructure/studio/JpaStudioRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/studio/JpaStudioRepository.java
@@ -1,11 +1,18 @@
 package org.example.studiopick.infrastructure.studio;
 
-import org.example.studiopick.domain.reservation.Reservation;
+import jakarta.persistence.LockModeType;
 import org.example.studiopick.domain.studio.Studio;
 import org.example.studiopick.domain.studio.StudioRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface JpaStudioRepository extends JpaRepository<Studio, Long>, StudioRepository {
 
-
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT s FROM Studio s WHERE s.id = :id")
+  Optional<Studio> findByIdWithLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## 📝 변경 사항
- 예약 생성 시 데이터베이스 락을 통한 동시성 처리 구현
- StudioRepository에 findByIdWithLock() 메서드 추가
- ReservationService에서 PESSIMISTIC_WRITE 락 적용
- 동시 예약 요청 시 Race Condition 방지 로직 구현

## 🎯 주요 기능
- 스튜디오 예약 생성 시 동시성 제어
- PESSIMISTIC_WRITE 락을 통한 배타적 접근 제어
- 동시 요청 시 순차 처리로 중복 예약 방지
- 트랜잭션 완료 후 자동 락 해제

## 🏗️ 구현 내용

### Service
- `ReservationService.create()` 메서드에 락 적용
- 기존 `studioRepository.findById()` → `studioRepository.findByIdWithLock()` 변경
- 락 획득된 Studio 엔티티를 직접 사용하도록 수정
- totalAmount 필드 누락 부분 수정

### Repository
- `StudioRepository.findByIdWithLock()` 메서드 시그니처 정의
- `JpaStudioRepository`에 PESSIMISTIC_WRITE 락 구현
- `@Lock(LockModeType.PESSIMISTIC_WRITE)` 어노테이션 적용
- 락 대상 스튜디오 조회 쿼리 구현

### Infrastructure
- Jakarta Persistence LockModeType import 추가
- JPA Lock, Query 어노테이션 import 추가
- 데이터베이스 레벨 락 메커니즘 활용

## ✅ 동시성 제어 로직
- 예약 요청 시 해당 스튜디오에 배타적 락 획득
- 다른 동시 요청은 락 해제까지 대기 상태
- 중복 검증 → 예약 생성 → 트랜잭션 커밋 순서 보장
- 트랜잭션 완료 후 자동으로 락 해제되어 대기 요청 처리

## 🔒 Race Condition 해결
**문제 상황 (Before)**:
```
사용자 A, B 동시 요청
1. A → 중복 검증 통과 ✅
2. B → 중복 검증 통과 ✅ (A 예약이 아직 저장 안됨)
3. A → 예약 저장 완료
4. B → 예약 저장 완료 (중복 예약 발생!)
```

**해결 방식 (After)**:
```
사용자 A, B 동시 요청
1. A → 스튜디오 락 획득 🔒
2. B → 락 대기 상태 ⏳
3. A → 중복 검증 → 예약 저장 → 트랜잭션 완료 → 락 해제
4. B → 락 획득 → 중복 검증 실패 → 예외 발생 ❌
```

## 🔄 관련 파일
- `ReservationService.java` - 락 기반 동시성 제어 로직
- `StudioRepository.java` - 락 메서드 인터페이스 정의
- `JpaStudioRepository.java` - PESSIMISTIC_WRITE 락 구현
- `Reservation.java` - totalAmount 필드 누락 수정

## 📊 성능 영향
- 락 대기로 인한 응답 시간 약간 증가 (동시 요청 시에만)
- 데이터 일관성 보장으로 비즈니스 안정성 향상
- 단일 스튜디오 단위 락으로 전체 시스템 성능 영향 최소화

## 📌 참고사항
- PESSIMISTIC_WRITE 락으로 확실한 동시성 제어 보장
- 스튜디오별 개별 락으로 다른 스튜디오 예약에는 영향 없음
- 트랜잭션 격리 레벨과 함께 작동하여 데이터 일관성 보장
- 데드락 방지를 위해 락 순서 일관성 유지 필요