### PR TITLE
이메일/비밀번호/이름/전화번호/닉네임 저장 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.0'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studiopick/StudioPickApplication.java
+++ b/src/main/java/org/example/studiopick/StudioPickApplication.java
@@ -2,7 +2,9 @@ package org.example.studiopick;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class StudioPickApplication {
 

--- a/src/main/java/org/example/studiopick/config/SecurityConfig.java
+++ b/src/main/java/org/example/studiopick/config/SecurityConfig.java
@@ -3,6 +3,8 @@ package org.example.studiopick.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -17,5 +19,10 @@ public class SecurityConfig {
         );
 
     return http.build();
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new BCryptPasswordEncoder();
   }
 }

--- a/src/main/java/org/example/studiopick/domain/user/UserRepository.java
+++ b/src/main/java/org/example/studiopick/domain/user/UserRepository.java
@@ -1,8 +1,11 @@
 package org.example.studiopick.domain.user;
 
+import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository {
-  public Optional<User> findById(Long id);
+public interface UserRepository extends JpaRepository<User, Long> {
+  Optional<User> findByEmail(String email);
+  Optional<User> findByPhone(String phone);
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/org/example/studiopick/domain/user/UserService.java
+++ b/src/main/java/org/example/studiopick/domain/user/UserService.java
@@ -1,0 +1,49 @@
+package org.example.studiopick.application.user;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.domain.user.User;
+import org.example.studiopick.domain.user.UserRepository;
+import org.example.studiopick.domain.user.UserSignupRequestDto;
+import org.example.studiopick.domain.common.enums.UserRole;
+import org.example.studiopick.domain.common.enums.UserStatus;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Transactional
+    public void signup(UserSignupRequestDto dto) {
+        // 중복 검사
+        if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
+        }
+
+        if (userRepository.findByPhone(dto.getPhone()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 전화번호입니다.");
+        }
+
+        if (userRepository.findByNickname(dto.getNickname()).isPresent()) {
+            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+        }
+
+        // User 엔티티 생성
+        User user = User.builder()
+                .email(dto.getEmail())
+                .password(passwordEncoder.encode(dto.getPassword()))
+                .name(dto.getName())
+                .phone(dto.getPhone())
+                .nickname(dto.getNickname())
+                .isStudioOwner(false)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        userRepository.save(user);
+    }
+}

--- a/src/main/java/org/example/studiopick/domain/user/UserSignupRequestDto.java
+++ b/src/main/java/org/example/studiopick/domain/user/UserSignupRequestDto.java
@@ -1,0 +1,31 @@
+package org.example.studiopick.domain.user;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class UserSignupRequestDto {
+
+    @NotBlank
+    @Email(message = "이메일 형식이 올바르지 않습니다.")
+    private String email;
+
+    @NotBlank
+    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    private String password;
+
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하고 총 11자리여야 합니다.")
+    private String phone;
+
+    @NotBlank
+    private String nickname;
+}

--- a/src/main/java/org/example/studiopick/web/user/UserController.java
+++ b/src/main/java/org/example/studiopick/web/user/UserController.java
@@ -1,0 +1,22 @@
+package org.example.studiopick.web.user;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.UserService;
+import org.example.studiopick.domain.user.UserSignupRequestDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/auth")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<String> register(@RequestBody @Valid UserSignupRequestDto requestDto) {
+        userService.signup(requestDto);
+        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+    }
+}


### PR DESCRIPTION
##  작업 내용 요약

- 사용자 정보 저장 API 구현
  - 이메일(email), 비밀번호(password), 이름(name), 전화번호(phone), 닉네임(nickname) 저장 가능
  - 각각의 필드에 대한 유효성 검증 추가
    - 이메일 형식 검증
    - 전화번호 하이픈 자동 처리
    - 비밀번호 최소 길이 등 조건 적용
  - 사용자 정보 저장 시 중복 체크 로직 적용 (예: 이메일 중복 방지)
  - json-server와 연동하여 사용자 정보 DB에 반영

##  테스트 및 확인

- Postman으로 API 정상 동작 테스트 완료
- 저장된 데이터가 정상적으로 DB에 반영되는 것 확인
- 예외 상황(중복, 형식 오류 등)에 대한 대응 확인
