### PR TITLE
비밀번호 암호화 및 유효성 검증

### DIFF
--- a/src/main/java/org/example/studiopick/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/studiopick/common/exception/GlobalExceptionHandler.java
@@ -3,27 +3,45 @@ package org.example.studiopick.common.exception;
 import org.example.studiopick.common.dto.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+  // 사용자 없음
   @ExceptionHandler(UserNotFoundException.class)
   public ResponseEntity<ApiResponse<Void>> handleUserNotFound(UserNotFoundException e) {
     ApiResponse<Void> response = new ApiResponse<>(false, null, e.getMessage());
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
   }
 
+  // 잘못된 파라미터
   @ExceptionHandler(InvalidParameterException.class)
   public ResponseEntity<ApiResponse<Void>> handleInvalidParameter(InvalidParameterException e) {
     ApiResponse<Void> response = new ApiResponse<>(false, null, e.getMessage());
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
   }
 
+  // 중복 이메일/닉네임 등 비즈니스 로직 에러
   @ExceptionHandler(IllegalArgumentException.class)
   public ResponseEntity<ApiResponse<Void>> handleIllegalArgument(IllegalArgumentException e) {
     ApiResponse<Void> response = new ApiResponse<>(false, null, e.getMessage());
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+  }
+
+  // DTO @Valid 검증 실패 (비밀번호 형식 등)
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+    String errorMessage = ex.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .findFirst()
+            .orElse("잘못된 입력입니다.");
+
+    ApiResponse<Void> response = new ApiResponse<>(false, null, errorMessage);
     return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
   }
 }

--- a/src/main/java/org/example/studiopick/domain/user/UserService.java
+++ b/src/main/java/org/example/studiopick/domain/user/UserService.java
@@ -1,4 +1,4 @@
-package org.example.studiopick.application.user;
+package org.example.studiopick.domain.user;
 
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.domain.user.User;
@@ -19,6 +19,7 @@ public class UserService {
 
     @Transactional
     public void signup(UserSignupRequestDto dto) {
+
         // 중복 검사
         if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
@@ -35,7 +36,7 @@ public class UserService {
         // User 엔티티 생성
         User user = User.builder()
                 .email(dto.getEmail())
-                .password(passwordEncoder.encode(dto.getPassword()))
+                .password(passwordEncoder.encode(dto.getPassword()))  // 암호화 OK
                 .name(dto.getName())
                 .phone(dto.getPhone())
                 .nickname(dto.getNickname())
@@ -45,5 +46,11 @@ public class UserService {
                 .build();
 
         userRepository.save(user);
+    }
+
+    // 정규식 조건 메서드
+    private boolean isValidPassword(String password) {
+        String pattern = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,}$";
+        return password != null && password.matches(pattern);
     }
 }

--- a/src/main/java/org/example/studiopick/domain/user/UserSignupRequestDto.java
+++ b/src/main/java/org/example/studiopick/domain/user/UserSignupRequestDto.java
@@ -11,21 +11,24 @@ import lombok.Setter;
 @Setter
 public class UserSignupRequestDto {
 
-    @NotBlank
+    @NotBlank(message = "이메일은 필수입니다.")
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
-    @NotBlank
-    @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다.")
+    @NotBlank(message = "비밀번호는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,}$",
+            message = "비밀번호는 8자 이상이며, 영문자, 숫자, 특수문자를 포함해야 합니다."
+    )
     private String password;
 
-    @NotBlank
+    @NotBlank(message = "이름은 필수입니다.")
     private String name;
 
-    @NotBlank
+    @NotBlank(message = "전화번호는 필수입니다.")
     @Pattern(regexp = "^010\\d{8}$", message = "전화번호는 010으로 시작하고 총 11자리여야 합니다.")
     private String phone;
 
-    @NotBlank
+    @NotBlank(message = "닉네임은 필수입니다.")
     private String nickname;
 }

--- a/src/main/java/org/example/studiopick/web/user/UserController.java
+++ b/src/main/java/org/example/studiopick/web/user/UserController.java
@@ -2,7 +2,7 @@ package org.example.studiopick.web.user;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.studiopick.application.user.UserService;
+import org.example.studiopick.domain.user.UserService;
 import org.example.studiopick.domain.user.UserSignupRequestDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;


### PR DESCRIPTION
비밀번호 암호화 및 유효성 검증 로직 추가

회원가입 시 비밀번호에 대해 정규식 유효성 검사 추가
(영문 + 숫자 + 특수문자 포함, 8자 이상)

@Pattern 어노테이션을 사용해 DTO에서 사전 검증

PasswordEncoder를 통해 비밀번호 암호화 후 저장

GlobalExceptionHandler 수정하여 validation 에러 메시지 응답 통일

Postman 테스트 완료 (에러 메시지 정상 출력 확인)