### PR TITLE
feat: 예약 취소

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.5.3'
+    id 'org.springframework.boot' version '3.1.5'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -35,7 +35,7 @@ dependencies {
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studiopick/application/reservation/dto/ReservationCancelRequest.java
+++ b/src/main/java/org/example/studiopick/application/reservation/dto/ReservationCancelRequest.java
@@ -1,0 +1,6 @@
+package org.example.studiopick.application.reservation.dto;
+
+public record ReservationCancelRequest(
+    Long userId,
+    String reason  // 취소 사유 (optional)
+) {}

--- a/src/main/java/org/example/studiopick/application/reservation/dto/ReservationCancelResponse.java
+++ b/src/main/java/org/example/studiopick/application/reservation/dto/ReservationCancelResponse.java
@@ -1,0 +1,11 @@
+package org.example.studiopick.application.reservation.dto;
+
+import org.example.studiopick.domain.common.enums.ReservationStatus;
+
+import java.time.LocalDateTime;
+
+public record ReservationCancelResponse(
+    Long reservationId,
+    ReservationStatus status,
+    LocalDateTime cancelledAt
+) {}

--- a/src/main/java/org/example/studiopick/domain/reservation/Reservation.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/Reservation.java
@@ -11,6 +11,7 @@ import org.example.studiopick.domain.studio.Studio;
 import org.example.studiopick.domain.user.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Entity
@@ -41,6 +42,12 @@ public class Reservation extends BaseEntity {
 
     @Column(name = "total_amount", nullable = false)
     private Long totalAmount;
+
+    @Column(name = "cancelled_reason")
+    private String cancelldReason;
+
+    @Column(name = "cancelled_at")
+    private LocalDateTime cancelledAt;
     
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
@@ -79,10 +86,6 @@ public class Reservation extends BaseEntity {
         this.status = ReservationStatus.CONFIRMED;
     }
     
-    public void cancel() {
-        this.status = ReservationStatus.CANCELLED;
-    }
-    
     public void complete() {
         this.status = ReservationStatus.COMPLETED;
     }
@@ -102,4 +105,31 @@ public class Reservation extends BaseEntity {
     public boolean isValidTimeRange() {
         return startTime != null && endTime != null && startTime.isBefore(endTime);
     }
+
+    // 취소 가능 여부 체크
+    public boolean isCancellable() {
+        return this.status == ReservationStatus.CONFIRMED ||
+            this.status == ReservationStatus.PENDING;
+    }
+
+    // 취소 가능 시간 체크 (24시간 전)
+    public boolean isWithinCancellationPeriod() {
+        LocalDateTime reservationDateTime = this.reservationDate.atTime(this.startTime);
+        LocalDateTime cancellationDeadline = reservationDateTime.minusHours(24);
+        return LocalDateTime.now().isBefore(cancellationDeadline);
+    }
+
+    // 취소 실행
+    public void cancel(String reason) {
+        if (!isCancellable()) {
+            throw new IllegalStateException("취소할 수 없는 예약 상태입니다.");
+        }
+        if (!isWithinCancellationPeriod()) {
+            throw new IllegalStateException("예약 시작 24시간 전까지만 취소 가능합니다.");
+        }
+        this.status = ReservationStatus.CANCELLED;
+        this.cancelldReason = reason;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -14,8 +14,6 @@ import java.util.Optional;
 public interface ReservationRepository {
   boolean existsOverlappingReservation(Long studioId, LocalDate date, ReservationStatus status, LocalTime start, LocalTime end);
 
-  Reservation save(Reservation reservation);
-
   List<Reservation> findByStudioIdAndReservationDateAndStatus(Long studioId, LocalDate reservationDate, ReservationStatus reservationStatus);
 
   Page<Reservation> findByUserIdOrderByReservationDateDesc(

--- a/src/main/java/org/example/studiopick/infrastructure/reservation/JpaReservationRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/reservation/JpaReservationRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Optional;
 
 public interface JpaReservationRepository extends JpaRepository<Reservation, Long>, ReservationRepository {
 
@@ -31,4 +32,5 @@ public interface JpaReservationRepository extends JpaRepository<Reservation, Lon
   );
 
   Page<Reservation> findByUserIdOrderByReservationDateDesc(Long userId, Pageable pageable);
+
 }

--- a/src/main/java/org/example/studiopick/web/ReservationController.java
+++ b/src/main/java/org/example/studiopick/web/ReservationController.java
@@ -2,10 +2,7 @@ package org.example.studiopick.web;
 
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.application.reservation.ReservationService;
-import org.example.studiopick.application.reservation.dto.AvailableTimesResponse;
-import org.example.studiopick.application.reservation.dto.ReservationCreateCommand;
-import org.example.studiopick.application.reservation.dto.ReservationResponse;
-import org.example.studiopick.application.reservation.dto.UserReservationListResponse;
+import org.example.studiopick.application.reservation.dto.*;
 import org.example.studiopick.common.dto.ApiResponse;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
@@ -65,4 +62,19 @@ public class ReservationController {
 
     return new ApiResponse<>(true, response, null);
   }
+
+  /**
+   * 예약 취소
+   */
+  @PutMapping("/{id}/cancel")
+  public ApiResponse<ReservationCancelResponse> cancelReservation(
+      @PathVariable Long id,
+      @RequestBody ReservationCancelRequest request
+  ) {
+    ReservationCancelResponse response = reservationService
+        .cancleReservation(id, request);
+
+    return new ApiResponse<>(true, response, "예약이 취소되었습니다.");
+  }
+
 }


### PR DESCRIPTION
feat: Add reservation cancellation functionality

**변경 사항**
- PUT /api/reservations/{id}/cancel 엔드포인트 구현
- ReservationController에서 예약 취소 요청 처리
- ReservationService에서 취소 비즈니스 로직 구현
- Reservation 도메인에서 취소 검증 및 상태 변경 로직 추가

**주요 기능**
- 스튜디오 예약 취소 기능
- 24시간 전 취소 정책 적용
- 본인 예약만 취소 가능한 권한 검증
- 취소 사유 및 취소 시간 추적
- 취소 가능 상태 검증 (CONFIRMED, PENDING만 취소 가능)

**구현 내용**

> Controller
- ReservationController.cancelReservation() 메서드 추가
- HTTP 200 OK 상태코드 반환
- ApiResponse 래퍼로 일관된 응답 형식 제공
- PathVariable로 예약 ID 받기, RequestBody로 취소 요청 정보 받기

> Service
- ReservationService.cancleReservation() 메서드 구현
- 예약 존재 여부 확인 및 조회
- 본인 예약 여부 검증 (userId 일치 확인)
- 도메인 객체의 cancel() 메서드 호출
- 변경된 예약 정보 저장 후 응답 생성

> Domain
- Reservation.cancel() 메서드 구현
- isCancellable() - 취소 가능 상태 검증 (CONFIRMED, PENDING)
- isWithinCancellationPeriod() - 24시간 전 취소 정책 검증
- 취소 실행 시 상태를 CANCELLED로 변경
- 취소 사유(cancelldReason)와 취소 시간(cancelledAt) 저장

**API 명세**
- PUT /api/reservations/{id}/cancel
- Content-Type: application/json
- Path Parameter: id (예약 ID)
- Request Body: ReservationCancelRequest (userId, reason)

**검증 로직**
- 예약 존재 여부 확인
- 본인 예약 여부 검증 (userId 일치)
- 취소 가능 상태 검증 (CONFIRMED 또는 PENDING)
- 24시간 전 취소 정책 적용 (예약 시작 24시간 전까지만 취소 가능)
- 이미 취소된 예약에 대한 중복 취소 방지

**관련 파일**
- ReservationController.java - REST API 엔드포인트
- ReservationService.java - 애플리케이션 서비스
- Reservation.java - 도메인 엔티티 (cancel 메서드 추가)
- ReservationCancelRequest.java - 취소 요청 DTO
- ReservationCancelResponse.java - 취소 응답 DTO
- ReservationStatus.java - 예약 상태 enum (CANCELLED 상태 활용)

**참고사항**
- 취소 시점은 LocalDateTime.now()로 자동 설정
- 취소 사유는 선택적(optional) 필드로 구현
- 도메인 주도 설계 원칙에 따라 비즈니스 로직을 도메인 객체에 캡슐화
- 트랜잭션 처리로 데이터 일관성 보장
- 예외 상황에 대한 명확한 에러 메시지 제공