### PR TITLE
카카오 OAuth2 소셜 로그인 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studiopick/application/user/dto/KakaoLoginRequestDto.java
+++ b/src/main/java/org/example/studiopick/application/user/dto/KakaoLoginRequestDto.java
@@ -1,0 +1,8 @@
+package org.example.studiopick.application.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class KakaoLoginRequestDto {
+    private String code; // 카카오 인가 코드
+}

--- a/src/main/java/org/example/studiopick/application/user/service/UserService.java
+++ b/src/main/java/org/example/studiopick/application/user/service/UserService.java
@@ -2,41 +2,43 @@ package org.example.studiopick.application.user.service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.application.user.dto.UserSignupRequestDto;
-import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.domain.common.enums.SocialProvider;
 import org.example.studiopick.domain.common.enums.UserRole;
 import org.example.studiopick.domain.common.enums.UserStatus;
+import org.example.studiopick.domain.user.entity.SocialAccount;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.domain.user.repository.SocialAccountRepository;
 import org.example.studiopick.domain.user.repository.UserRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
 
     private final UserRepository userRepository;
+    private final SocialAccountRepository socialAccountRepository;
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
     public void signup(UserSignupRequestDto dto) {
-
-        // 중복 검사
         if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 이메일 입니다.");
         }
-
         if (userRepository.findByPhone(dto.getPhone()).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 휴대폰 번호 입니다.");
         }
-
         if (userRepository.findByNickname(dto.getNickname()).isPresent()) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임 입니다.");
         }
 
-        // User 엔티티 생성
         User user = User.builder()
                 .email(dto.getEmail())
-                .password(passwordEncoder.encode(dto.getPassword()))  // 암호화 OK
+                .password(passwordEncoder.encode(dto.getPassword()))
                 .name(dto.getName())
                 .phone(dto.getPhone())
                 .nickname(dto.getNickname())
@@ -49,17 +51,52 @@ public class UserService {
     }
 
     public boolean validateEmail(String email) {
-        return !userRepository.existsByEmail(email);  // true: 사용 가능 / false: 이미 존재
+        return !userRepository.existsByEmail(email);
     }
 
     public boolean validatePhone(String phone) {
-        return !userRepository.existsByPhone(phone); // true: 사용 가능 / false: 이미 있음
+        return !userRepository.existsByPhone(phone);
     }
 
-
-    // 패스워드 형식 검사 메서드
     private boolean isValidPassword(String password) {
         String pattern = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[!@#$%^&*()])[A-Za-z\\d!@#$%^&*()]{8,}$";
         return password != null && password.matches(pattern);
+    }
+
+    /**
+     * 카카오 등 소셜 로그인 처리 메서드
+     */
+    @Transactional
+    public User loginOrRegisterSocialUser(String provider, String socialId, String email, String nickname, String profileImage) {
+        SocialProvider providerEnum = SocialProvider.valueOf(provider.toUpperCase());
+        Optional<User> existingUser = userRepository
+                .findBySocialAccountsProviderAndSocialAccountsSocialId(providerEnum, socialId);
+
+        if (existingUser.isPresent()) {
+            return existingUser.get(); // 기존 유저면 바로 반환
+        }
+
+        // 신규 유저 생성
+        User newUser = User.builder()
+                .email(email != null ? email : UUID.randomUUID().toString() + "@social.com")
+                .password(null) // 소셜 로그인은 비밀번호 없음
+                .nickname(nickname)
+                .isStudioOwner(false)
+                .status(UserStatus.ACTIVE)
+                .role(UserRole.USER)
+                .build();
+
+        userRepository.save(newUser);
+
+        // 소셜 계정 정보 저장
+        SocialAccount socialAccount = SocialAccount.builder()
+                .provider(SocialProvider.valueOf(provider))
+                .socialId(socialId)
+                .user(newUser)
+                .build();
+
+        socialAccountRepository.save(socialAccount);
+
+        return newUser;
     }
 }

--- a/src/main/java/org/example/studiopick/config/SecurityConfig.java
+++ b/src/main/java/org/example/studiopick/config/SecurityConfig.java
@@ -22,51 +22,53 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-  private final CustomUserDetailsService customUserDetailsService;
-  private final JwtProvider jwtProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtProvider jwtProvider;
 
-  @Bean
-  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-    http
-            .csrf(csrf -> csrf.disable())
-            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-            .authorizeHttpRequests(auth -> auth
-                    .requestMatchers(
-                            "/api/auth/register",
-                            "/api/auth/validate/**",
-                            "/api/auth/login",
-                            "/swagger-ui/**",
-                            "/v3/api-docs/**"
-                    ).permitAll()
-                    .anyRequest().authenticated()
-            )
-            .formLogin(login -> login.disable())
-            .httpBasic(basic -> basic.disable())
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/register",
+                                "/api/auth/validate/**",
+                                "/api/auth/login",
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api/auth/oauth/**",
+                                "/oauth2/**" // OAuth2 리디렉션 경로 허용
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .formLogin(login -> login.disable())
+                .httpBasic(basic -> basic.disable())
 
-            // 401 Unauthorized 설정 추가
-            .exceptionHandling(exception -> exception
-                    .authenticationEntryPoint((request, response, authException) -> {
-                      response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "잘못된 이메일 또는 비밀번호입니다.");
-                    })
-            )
+                // 401 Unauthorized 핸들링
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "잘못된 이메일 또는 비밀번호입니다.");
+                        })
+                )
 
-            .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
-    return http.build();
-  }
+        return http.build();
+    }
 
-  @Bean
-  public JwtAuthenticationFilter jwtAuthenticationFilter() {
-    return new JwtAuthenticationFilter(jwtProvider, customUserDetailsService);
-  }
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtProvider, customUserDetailsService);
+    }
 
-  @Bean
-  public PasswordEncoder passwordEncoder() {
-    return new BCryptPasswordEncoder();
-  }
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
-  @Bean
-  public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
-    return config.getAuthenticationManager();
-  }
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
 }

--- a/src/main/java/org/example/studiopick/domain/user/entity/SocialAccount.java
+++ b/src/main/java/org/example/studiopick/domain/user/entity/SocialAccount.java
@@ -13,25 +13,25 @@ import org.example.studiopick.domain.common.enums.SocialProvider;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SocialAccount extends BaseEntity {
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "provider", nullable = false)
     private SocialProvider provider;
-    
+
     @Column(name = "social_id", nullable = false, length = 50)
     private String socialId;
-    
+
     @Builder
     public SocialAccount(User user, SocialProvider provider, String socialId) {
         this.user = user;
         this.provider = provider;
         this.socialId = socialId;
     }
-    
+
     public void updateSocialId(String socialId) {
         this.socialId = socialId;
     }

--- a/src/main/java/org/example/studiopick/domain/user/entity/User.java
+++ b/src/main/java/org/example/studiopick/domain/user/entity/User.java
@@ -17,86 +17,86 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
-    
+
     @Column(name = "email", unique = true, nullable = false, length = 30)
     private String email;
-    
+
     @Column(name = "password", length = 255)
     private String password;
-    
+
     @Column(name = "name", nullable = false, length = 7)
     private String name;
-    
+
     @Column(name = "phone", unique = true, nullable = false, length = 11)
     private String phone;
-    
+
     @Column(name = "nickname", unique = true, nullable = false, length = 10)
     private String nickname;
-    
+
     @Column(name = "is_studio_owner", nullable = false)
     private Boolean isStudioOwner = false;
-    
+
     @Column(name = "login_fail_count", nullable = false)
     private Short loginFailCount = 0;
-    
+
     @Column(name = "email_verified", nullable = false)
     private Boolean emailVerified = false;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     private UserRole role = UserRole.USER;
-    
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAccount> socialAccounts = new ArrayList<>();
-    
+
     @Builder
-    public User(String email, String password, String name, String phone, String nickname, 
+    public User(String email, String password, String name, String phone, String nickname,
                 Boolean isStudioOwner, UserStatus status, UserRole role) {
         this.email = email;
         this.password = password;
-        this.name = name;
-        this.phone = phone;
+        this.name = name != null ? name : "소셜회원"; // ✅ 기본값
+        this.phone = phone != null ? phone : "00000000000"; // ✅ 기본값
         this.nickname = nickname;
         this.isStudioOwner = isStudioOwner != null ? isStudioOwner : false;
         this.status = status != null ? status : UserStatus.ACTIVE;
         this.role = role != null ? role : UserRole.USER;
     }
-    
+
     public void changePassword(String newPassword) {
         this.password = newPassword;
     }
-    
+
     public void updateProfile(String name, String phone, String nickname) {
         this.name = name;
         this.phone = phone;
         this.nickname = nickname;
     }
-    
+
     public void increaseLoginFailCount() {
         this.loginFailCount++;
     }
-    
+
     public void resetLoginFailCount() {
         this.loginFailCount = 0;
     }
-    
+
     public void verifyEmail() {
         this.emailVerified = true;
     }
-    
+
     public void changeStatus(UserStatus status) {
         this.status = status;
     }
-    
+
     public void promoteToStudioOwner() {
         this.isStudioOwner = true;
         this.role = UserRole.STUDIO_OWNER;
     }
-    
+
     public void changeRole(UserRole role) {
         this.role = role;
     }

--- a/src/main/java/org/example/studiopick/domain/user/repository/SocialAccountRepository.java
+++ b/src/main/java/org/example/studiopick/domain/user/repository/SocialAccountRepository.java
@@ -1,0 +1,12 @@
+package org.example.studiopick.domain.user.repository;
+
+import org.example.studiopick.domain.user.entity.SocialAccount;
+import org.example.studiopick.domain.common.enums.SocialProvider;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SocialAccountRepository extends JpaRepository<SocialAccount, Long> {
+
+    Optional<SocialAccount> findByProviderAndSocialId(SocialProvider provider, String socialId);
+}

--- a/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
@@ -1,16 +1,20 @@
 package org.example.studiopick.domain.user.repository;
 
+import org.example.studiopick.domain.common.enums.SocialProvider;
 import org.example.studiopick.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+
+  // 일반 로그인 및 중복검사
   Optional<User> findByEmail(String email);
   Optional<User> findByPhone(String phone);
   Optional<User> findByNickname(String nickname);
-
   boolean existsByEmail(String email);
   boolean existsByPhone(String phone);
 
+  // 소셜 로그인용
+  Optional<User> findBySocialAccountsProviderAndSocialAccountsSocialId(SocialProvider provider, String socialId);
 }

--- a/src/main/java/org/example/studiopick/infrastructure/oauth/KakaoOAuthClient.java
+++ b/src/main/java/org/example/studiopick/infrastructure/oauth/KakaoOAuthClient.java
@@ -1,0 +1,81 @@
+package org.example.studiopick.infrastructure.oauth;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.Map;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoOAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${oauth.kakao.client-id}")
+    private String clientId;
+
+    @Value("${oauth.kakao.redirect-uri}")
+    private String redirectUri;
+
+    public String getAccessToken(String code) {
+        String tokenUrl = "https://kauth.kakao.com/oauth/token";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(tokenUrl)
+                .queryParam("grant_type", "authorization_code")
+                .queryParam("client_id", clientId)
+                .queryParam("redirect_uri", redirectUri)
+                .queryParam("code", code);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<Map> response = restTemplate.exchange(
+                    builder.toUriString(),
+                    HttpMethod.POST,
+                    entity,
+                    Map.class
+            );
+
+            log.warn("카카오 access token 응답 코드: {}", response.getStatusCode());
+            log.warn("카카오 access token 응답 바디: {}", response.getBody());
+
+            Map<String, Object> body = response.getBody();
+            if (body == null || body.get("access_token") == null) {
+                throw new RuntimeException("카카오 액세스 토큰 발급 실패 (응답 없음)");
+            }
+
+            return body.get("access_token").toString();
+
+        } catch (Exception e) {
+            log.error("❌ 카카오 access token 요청 실패", e);
+            throw new RuntimeException("카카오 access token 요청 중 예외 발생", e);
+        }
+    }
+
+    public Map<String, Object> getUserInfo(String accessToken) {
+        String userInfoUrl = "https://kapi.kakao.com/v2/user/me";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<?> entity = new HttpEntity<>(headers);
+
+        ResponseEntity<Map> response = restTemplate.exchange(
+                userInfoUrl,
+                HttpMethod.GET,
+                entity,
+                Map.class
+        );
+
+        return response.getBody();
+    }
+}

--- a/src/main/java/org/example/studiopick/security/CustomOAuth2UserService.java
+++ b/src/main/java/org/example/studiopick/security/CustomOAuth2UserService.java
@@ -1,0 +1,63 @@
+package org.example.studiopick.security;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studiopick.application.user.service.UserService;
+import org.example.studiopick.domain.user.entity.User;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // ex: kakao
+        String accessToken = userRequest.getAccessToken().getTokenValue();
+
+        log.info("OAuth2 로그인 요청 - provider: {}", registrationId);
+
+        // 카카오인 경우 사용자 정보 파싱
+        if ("kakao".equals(registrationId)) {
+            return processKakaoUser(oAuth2User);
+        }
+
+        throw new IllegalArgumentException("지원하지 않는 OAuth2 제공자입니다: " + registrationId);
+    }
+
+    private OAuth2User processKakaoUser(OAuth2User oAuth2User) {
+        // 여기서 카카오 사용자 정보를 꺼내고, userService를 통해 처리하게 될 거야 (다음 단계에서 구현)
+
+        log.info("카카오 사용자 정보: {}", oAuth2User.getAttributes());
+
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        Long kakaoId = ((Number) attributes.get("id")).longValue();
+        String socialId = "kakao_" + kakaoId;
+
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        String email = (String) kakaoAccount.get("email");
+
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        String nickname = (String) profile.get("nickname");
+        String profileImage = (String) profile.get("profile_image_url");
+
+        // userService에 로그인/회원가입 처리 위임 (다음 단계에서 구현)
+        User user = userService.loginOrRegisterSocialUser("kakao", socialId, email, nickname, profileImage);
+
+        // UserPrincipal로 감싸서 반환
+        return UserPrincipal.create(user, attributes);
+
+    }
+}

--- a/src/main/java/org/example/studiopick/web/user/AuthController.java
+++ b/src/main/java/org/example/studiopick/web/user/AuthController.java
@@ -4,6 +4,7 @@ package org.example.studiopick.web.user;
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.application.user.dto.JwtTokenResponseDto;
 import org.example.studiopick.application.user.dto.UserLoginRequestDto;
+import org.example.studiopick.infrastructure.oauth.KakaoOAuthClient;
 import org.example.studiopick.security.JwtProvider;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -14,6 +15,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
@@ -21,6 +24,7 @@ public class AuthController {
 
     private final AuthenticationManager authenticationManager;
     private final JwtProvider jwtProvider;
+    private final KakaoOAuthClient kakaoOAuthClient;
 
     @PostMapping("/login")
     public ResponseEntity<JwtTokenResponseDto> login(@RequestBody UserLoginRequestDto requestDto) {
@@ -35,5 +39,15 @@ public class AuthController {
 
         // 3. 응답 반환
         return ResponseEntity.ok(new JwtTokenResponseDto(accessToken, refreshToken));
+    }
+
+
+    @PostMapping("/oauth/kakao")
+    public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> body) {
+        String code = body.get("code");
+        String accessToken = kakaoOAuthClient.getAccessToken(code); // 여기서 호출됨
+
+        // 이후 사용자 정보 요청, 로그인 처리 등 구현 예정
+        return ResponseEntity.ok("AccessToken: " + accessToken);
     }
 }


### PR DESCRIPTION
##  작업 내용
- 카카오 OAuth2 소셜 로그인 기능 연동
- 인가 코드(code)를 통해 access token 발급 처리 구현
- KakaoOAuthClient: token 발급 및 사용자 정보 조회 로직 구현
- `/api/auth/oauth/kakao` 엔드포인트 추가
- Postman을 통해 access token 정상 응답 확인 완료

## 테스트
- Postman에서 인가 코드로 요청 → 200 OK 응답 및 access token 수신 확인
- 서버 로그에 access token 응답 및 상태코드 정상 출력 확인