### PR TITLE
작품 피드 조회 api(인기순/최신순)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'org.postgresql:postgresql'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/org/example/studiopick/StudioPickApplication.java
+++ b/src/main/java/org/example/studiopick/StudioPickApplication.java
@@ -1,12 +1,13 @@
 package org.example.studiopick;
 
+import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
-
+@MapperScan("org.example.studiopick.infrastructure.mybatis")
 public class StudioPickApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkFeedDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkFeedDto.java
@@ -1,0 +1,22 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+
+public class ArtworkFeedDto {
+    private Long id;
+    private String title;
+    private String description;
+    private String imageUrl; //대표 이미지 url
+    private String hashtags;
+    private String artistNickname; // 작성자 닉네임
+    private String studioName;
+    private int likeCount; // 좋아요 수
+    private boolean isPublic; // 공개여부
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/studiopick/config/SecurityConfig.java
+++ b/src/main/java/org/example/studiopick/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                "/api/artworks",
                                 "/api/auth/register",
                                 "/api/auth/validate/**",
                                 "/api/auth/login",

--- a/src/main/java/org/example/studiopick/domain/artwork/Artwork.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/Artwork.java
@@ -35,6 +35,12 @@ public class Artwork extends BaseEntity {
     
     @Column(name = "is_public", nullable = false)
     private Boolean isPublic = true;
+
+    @Column(name = "like_count", nullable = false)
+    private Integer likeCount = 0;
+
+    @Column(name = "comment_count", nullable = false)
+    private Integer commentCount = 0;
     
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
@@ -1,0 +1,19 @@
+package org.example.studiopick.domain.artwork;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
+import org.example.studiopick.infrastructure.mybatis.ArtworkMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArtworkService {
+
+    private final ArtworkMapper artworkMapper;
+
+    public List<ArtworkFeedDto> getArtworks(String sort, int offset, int limit, String hashtags) {
+        return artworkMapper.findAllSorted(sort, offset, limit, hashtags);
+    }
+}

--- a/src/main/java/org/example/studiopick/infrastructure/mybatis/ArtworkMapper.java
+++ b/src/main/java/org/example/studiopick/infrastructure/mybatis/ArtworkMapper.java
@@ -1,0 +1,16 @@
+package org.example.studiopick.infrastructure.mybatis;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
+import org.example.studiopick.domain.artwork.Artwork;
+
+import java.util.List;
+
+@Mapper
+public interface ArtworkMapper {
+    List<ArtworkFeedDto> findAllSorted(@Param("sort") String sort,
+                                       @Param("offset") int offset,
+                                       @Param("limit") int limit,
+                                       @Param("hashtags") String hashtags);
+}

--- a/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
+++ b/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
@@ -1,0 +1,40 @@
+package org.example.studiopick.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.common.dto.ApiResponse;
+import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
+import org.example.studiopick.domain.artwork.Artwork;
+import org.example.studiopick.domain.artwork.ArtworkService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/artworks")
+public class ArtWorkController {
+
+    private final ArtworkService artworkService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getArtworks(
+            @RequestParam(defaultValue = "popular") String sort,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "12") int limit,
+            @RequestParam(required = false) String hashtags
+    ) {
+        int offset = (page - 1) * limit;
+        List<ArtworkFeedDto> artworks = artworkService.getArtworks(sort, offset, limit, hashtags);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("artworks", artworks);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, result, null));
+    }
+}

--- a/src/main/resources/mappers/artwork/ArtworkMapper.xml
+++ b/src/main/resources/mappers/artwork/ArtworkMapper.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.studiopick.infrastructure.mybatis.ArtworkMapper">
+
+    <select id="findAllSorted" resultType="org.example.studiopick.common.dto.artwork.ArtworkFeedDto">
+        SELECT
+        a.id, a.title, a.description, a.image_url AS imageUrl, a.hashtags,
+        u.nickname AS artistNickname, s.name AS studioName,
+        a.like_count AS likeCount, a.is_public AS isPublic, a.created_at AS createdAt
+        FROM artwork a
+        JOIN "user" u ON a.user_id = u.id
+        JOIN studio s ON a.studio_id = s.id
+        WHERE a.is_public = true
+        <if test="hashtags != null and hashtags != ''">
+            AND a.hashtags ILIKE '%' || #{hashtags} || '%'
+        </if>
+        <choose>
+            <when test='"popular".equals(sort)'>
+                ORDER BY a.like_count DESC
+            </when>
+            <when test='"latest".equals(sort)'>
+                ORDER BY a.created_at DESC
+            </when>
+            <otherwise>
+                ORDER BY a.created_at DESC
+            </otherwise>
+        </choose>
+        LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
+
+</mapper>


### PR DESCRIPTION
구현 내용
작품 피드 조회 API (/api/artworks) 구현

정렬 옵션 지원

popular: 좋아요 많은 순

latest: 최신순 (기본값)

해시태그 필터링 기능 (hashtags 파라미터)

페이징 처리 (offset, limit 파라미터)

✅ 테스트 항목
 쿼리 파라미터 없이 전체 조회

 인기순/최신순 정렬 확인

 해시태그 포함된 데이터 필터링

 limit, offset 조절 시 응답 개수/순서 확인

🔍 기타 참고사항
artwork, user, studio 테이블에 더미 데이터 직접 삽입하여 테스트 완료

JWT 없이도 접근 가능한 퍼블릭 API로 보안 정책 적용 제외됨 (permitAll 처리)

