### PR TITLE
사용자 프로필 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
+<<<<<<< Updated upstream
+=======
+
+>>>>>>> Stashed changes
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studiopick/application/user/dto/UserProfileResponseDto.java
+++ b/src/main/java/org/example/studiopick/application/user/dto/UserProfileResponseDto.java
@@ -1,0 +1,19 @@
+package org.example.studiopick.application.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserProfileResponseDto {
+    private Long id;
+    private String email;
+    private String name;
+    private String phone;
+    private String nickname;
+    private boolean isStudioOwner;
+    private String status;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/studiopick/application/user/service/UserService.java
+++ b/src/main/java/org/example/studiopick/application/user/service/UserService.java
@@ -1,6 +1,7 @@
 package org.example.studiopick.application.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.dto.UserProfileResponseDto;
 import org.example.studiopick.application.user.dto.UserSignupRequestDto;
 import org.example.studiopick.domain.common.enums.SocialProvider;
 import org.example.studiopick.domain.common.enums.UserRole;
@@ -14,6 +15,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -100,4 +102,22 @@ public class UserService {
 
         return newUser;
     }
+
+    @Transactional(readOnly = true)
+    public UserProfileResponseDto getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        return UserProfileResponseDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .phone(user.getPhone())
+                .nickname(user.getNickname())
+                .isStudioOwner(user.isStudioOwner())
+                .status(user.getStatus().name())
+                .createdAt(user.getCreatedAt())
+                .build();
+    }
+
 }

--- a/src/main/java/org/example/studiopick/domain/user/entity/User.java
+++ b/src/main/java/org/example/studiopick/domain/user/entity/User.java
@@ -101,6 +101,7 @@ public class User extends BaseEntity {
         this.role = role;
     }
 
+<<<<<<< Updated upstream
     // 관리자용 업데이트 메서드
     public void updateName(String name){
         if(name != null && !name.isEmpty()){this.name = name;}
@@ -143,4 +144,10 @@ public class User extends BaseEntity {
     public boolean isAdmin() {
         return this.role == UserRole.ADMIN;
     }
+=======
+    public boolean isStudioOwner() {
+        return Boolean.TRUE.equals(this.isStudioOwner);
+    }
+
+>>>>>>> Stashed changes
 }

--- a/src/main/java/org/example/studiopick/security/UserPrincipal.java
+++ b/src/main/java/org/example/studiopick/security/UserPrincipal.java
@@ -36,6 +36,11 @@ public class UserPrincipal implements OAuth2User, UserDetails {
         this.attributes = attributes;
     }
 
+    // ✅ 여기에 추가됨
+    public Long getUserId() {
+        return user.getId();
+    }
+
     // OAuth2User 필수
     @Override
     public Map<String, Object> getAttributes() {

--- a/src/main/java/org/example/studiopick/web/user/AuthController.java
+++ b/src/main/java/org/example/studiopick/web/user/AuthController.java
@@ -1,11 +1,11 @@
 package org.example.studiopick.web.user;
 
-
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.application.token.service.TokenService;
-import org.example.studiopick.application.user.dto.JwtTokenResponseDto;
-import org.example.studiopick.application.user.dto.UserLoginRequestDto;
+import org.example.studiopick.application.user.dto.*;
+import org.example.studiopick.application.user.service.UserService;
 import org.example.studiopick.common.util.JwtUtil;
 import org.example.studiopick.infrastructure.oauth.KakaoOAuthClient;
 import org.example.studiopick.security.JwtProvider;
@@ -13,16 +13,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/auth")
 @RequiredArgsConstructor
+@RequestMapping("/api/auth")
 public class AuthController {
 
     private final AuthenticationManager authenticationManager;
@@ -30,32 +27,61 @@ public class AuthController {
     private final KakaoOAuthClient kakaoOAuthClient;
     private final TokenService tokenService;
     private final JwtUtil jwtUtil;
+    private final UserService userService;
 
+    // 회원가입
+    @PostMapping("/register")
+    public ResponseEntity<String> register(@RequestBody @Valid UserSignupRequestDto requestDto) {
+        userService.signup(requestDto);
+        return ResponseEntity.ok("회원가입이 완료되었습니다.");
+    }
+
+    // 이메일 중복 검사
+    @PostMapping("/validate/email")
+    public ResponseEntity<String> validateEmail(@RequestBody @Valid EmailValidateRequestDto dto) {
+        boolean available = userService.validateEmail(dto.getEmail());
+
+        if (!available) {
+            return ResponseEntity.badRequest().body("이미 사용 중인 이메일입니다.");
+        }
+
+        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+    }
+
+    // 휴대폰 중복 검사
+    @PostMapping("/validate/phone")
+    public ResponseEntity<String> validatePhone(@Valid @RequestBody PhoneValidateRequestDto requestDto) {
+        boolean available = userService.validatePhone(requestDto.getPhone());
+
+        if (!available) {
+            return ResponseEntity.badRequest().body("이미 사용 중인 휴대폰번호입니다.");
+        }
+
+        return ResponseEntity.ok("사용 가능한 휴대폰번호입니다.");
+    }
+
+    // 이메일 로그인
     @PostMapping("/login")
     public ResponseEntity<JwtTokenResponseDto> login(@RequestBody UserLoginRequestDto requestDto) {
-        // 1. 인증 시도
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(requestDto.getEmail(), requestDto.getPassword())
         );
 
-        // 2. 인증 성공 → JWT 발급
         String accessToken = jwtProvider.createAccessToken(requestDto.getEmail());
         String refreshToken = jwtProvider.createRefreshToken(requestDto.getEmail());
 
-        // 3. 응답 반환
         return ResponseEntity.ok(new JwtTokenResponseDto(accessToken, refreshToken));
     }
 
-
+    // 카카오 로그인
     @PostMapping("/oauth/kakao")
     public ResponseEntity<?> kakaoLogin(@RequestBody Map<String, String> body) {
         String code = body.get("code");
-        String accessToken = kakaoOAuthClient.getAccessToken(code); // 여기서 호출됨
-
-        // 이후 사용자 정보 요청, 로그인 처리 등 구현 예정
+        String accessToken = kakaoOAuthClient.getAccessToken(code);
         return ResponseEntity.ok("AccessToken: " + accessToken);
     }
 
+    // 로그아웃 (토큰 블랙리스트 등록)
     @PostMapping("/logout")
     public ResponseEntity<Map<String, Object>> logout(HttpServletRequest request) {
         String authHeader = request.getHeader("Authorization");
@@ -76,5 +102,4 @@ public class AuthController {
                 "message", "로그아웃되었습니다"
         ));
     }
-
 }

--- a/src/main/java/org/example/studiopick/web/user/UserController.java
+++ b/src/main/java/org/example/studiopick/web/user/UserController.java
@@ -1,45 +1,32 @@
 package org.example.studiopick.web.user;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.example.studiopick.application.user.dto.EmailValidateRequestDto;
-import org.example.studiopick.application.user.dto.PhoneValidateRequestDto;
-import org.example.studiopick.application.user.dto.UserSignupRequestDto;
+import org.example.studiopick.application.user.dto.UserProfileResponseDto;
 import org.example.studiopick.application.user.service.UserService;
+import org.example.studiopick.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/auth")
+@RequestMapping("/api/users")
 public class UserController {
 
     private final UserService userService;
 
-    @PostMapping("/register")
-    public ResponseEntity<String> register(@RequestBody @Valid UserSignupRequestDto requestDto) {
-        userService.signup(requestDto);
-        return ResponseEntity.ok("회원가입이 완료되었습니다.");
-    }
-    // 이메일 중복검사 API
-    @PostMapping("/validate/email")
-    public ResponseEntity<String> validateEmail(@RequestBody @Valid EmailValidateRequestDto dto) {
-        boolean available = userService.validateEmail(dto.getEmail());
+    @GetMapping("/profile")
+    public ResponseEntity<Map<String, Object>> getUserProfile(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUserId();
+        UserProfileResponseDto profile = userService.getUserProfile(userId);
 
-        if (!available) {
-            return ResponseEntity.badRequest().body("이미 사용 중인 이메일입니다.");
-        }
+        Map<String, Object> response = new HashMap<>();
+        response.put("success", true);
+        response.put("data", profile);
 
-        return ResponseEntity.ok("사용 가능한 이메일입니다.");
+        return ResponseEntity.ok(response);
     }
-    // 휴대폰 번호 중복 검사 API
-    @PostMapping("/api/auth/validate/phone")
-    public ResponseEntity<String> validatePhone(@Valid @RequestBody PhoneValidateRequestDto requestDto) {
-        userService.validatePhone(requestDto.getPhone());
-        return ResponseEntity.ok("사용 가능한 휴대폰번호입니다.");
-    }
-
 }


### PR DESCRIPTION
## 작업 내용
- 로그인한 사용자의 정보를 조회하는 `/api/users/profile` API 구현
- 응답 형태는 `{"success": true, "data": {...}}` 포맷으로 반환
- 인증된 사용자 정보는 `@AuthenticationPrincipal UserPrincipal`로 처리

## 변경 사항
- `UserService`에 `getUserProfile(Long userId)` 메서드 추가
- `UserController` 생성 및 `/api/users/profile` 엔드포인트 구현
- `UserProfileResponseDto` 생성
- `UserPrincipal`에 `getUserId()` 메서드 추가

## 테스트
- Postman을 통해 accessToken 포함 GET 요청 테스트 완료
- 정상적으로 사용자 프로필 반환 확인