### PR TITLE
feat:전체 매출 통계 및 분석 API 구현

### DIFF
--- a/src/main/java/org/example/studiopick/application/admin/AdminSalesService.java
+++ b/src/main/java/org/example/studiopick/application/admin/AdminSalesService.java
@@ -1,0 +1,363 @@
+package org.example.studiopick.application.admin;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studiopick.application.admin.dto.sales.*;
+import org.example.studiopick.common.validator.PaginationValidator;
+import org.example.studiopick.domain.common.enums.PaymentMethod;
+import org.example.studiopick.domain.common.enums.PaymentStatus;
+import org.example.studiopick.domain.payment.Payment;
+import org.example.studiopick.infrastructure.payment.JpaPaymentRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminSalesService {
+
+  private final JpaPaymentRepository paymentRepository;
+  private final PaginationValidator paginationValidator;
+
+  /**
+   * 전체 매출 통계 조회
+   */
+  public AdminSalesStatsResponse getSalesStats() {
+    // 전체 매출
+    BigDecimal totalSales = paymentRepository.getTotalSalesByStatus(PaymentStatus.PAID);
+
+    // 오늘 매출
+    LocalDateTime todayStart = LocalDate.now().atStartOfDay();
+    LocalDateTime todayEnd = LocalDate.now().atTime(LocalTime.MAX);
+    BigDecimal todaySales = paymentRepository.getSalesByDateRangeAndStatus(
+        todayStart, todayEnd, PaymentStatus.PAID);
+
+    // 이번 달 매출
+    LocalDateTime monthStart = LocalDate.now().withDayOfMonth(1).atStartOfDay();
+    LocalDateTime monthEnd = LocalDate.now().atTime(LocalTime.MAX);
+    BigDecimal thisMonthSales = paymentRepository.getSalesByDateRangeAndStatus(
+        monthStart, monthEnd, PaymentStatus.PAID);
+
+    // 이번 년도 매출
+    LocalDateTime yearStart = LocalDate.now().withDayOfYear(1).atStartOfDay();
+    LocalDateTime yearEnd = LocalDate.now().atTime(LocalTime.MAX);
+    BigDecimal thisYearSales = paymentRepository.getSalesByDateRangeAndStatus(
+        yearStart, yearEnd, PaymentStatus.PAID);
+
+    // 환불 금액
+    BigDecimal totalRefunds = paymentRepository.getTotalSalesByStatus(PaymentStatus.REFUNDED);
+
+    // 결제 건수 통계
+    long totalPayments = paymentRepository.countByStatus(PaymentStatus.PAID);
+    long totalRefundCount = paymentRepository.countByStatus(PaymentStatus.REFUNDED);
+
+    return new AdminSalesStatsResponse(
+        totalSales != null ? totalSales : BigDecimal.ZERO,
+        todaySales != null ? todaySales : BigDecimal.ZERO,
+        thisMonthSales != null ? thisMonthSales : BigDecimal.ZERO,
+        thisYearSales != null ? thisYearSales : BigDecimal.ZERO,
+        totalRefunds != null ? totalRefunds : BigDecimal.ZERO,
+        totalPayments,
+        totalRefundCount
+    );
+  }
+
+  /**
+   * 기간별 매출 트렌드 분석
+   */
+  public AdminSalesTrendResponse getSalesTrend(String startDate, String endDate, String period) {
+    LocalDate start = LocalDate.parse(startDate);
+    LocalDate end = LocalDate.parse(endDate);
+    LocalDateTime startDateTime = start.atStartOfDay();
+    LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
+
+    List<AdminSalesTrendData> trendData = new ArrayList<>();
+
+    switch (period.toLowerCase()) {
+      case "daily" -> trendData = getDailySalesTrend(start, end);
+      case "monthly" -> trendData = getMonthlySalesTrend(start, end);
+      case "yearly" -> trendData = getYearlySalesTrend(start, end);
+      default -> throw new IllegalArgumentException("지원하지 않는 기간 타입입니다: " + period);
+    }
+
+    // 기간별 총 매출
+    BigDecimal totalSales = paymentRepository.getSalesByDateRangeAndStatus(
+        startDateTime, endDateTime, PaymentStatus.PAID);
+
+    return new AdminSalesTrendResponse(
+        startDate,
+        endDate,
+        period,
+        totalSales != null ? totalSales : BigDecimal.ZERO,
+        trendData
+    );
+  }
+
+  /**
+   * 스튜디오별 매출 분석
+   */
+  public AdminStudioSalesResponse getStudioSalesAnalysis(
+      int page, int size, String startDate, String endDate) {
+
+    paginationValidator.validatePaginationParameters(page, size);
+
+    LocalDate start = startDate != null ? LocalDate.parse(startDate) : LocalDate.now().minusMonths(1);
+    LocalDate end = endDate != null ? LocalDate.parse(endDate) : LocalDate.now();
+    LocalDateTime startDateTime = start.atStartOfDay();
+    LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
+
+    Pageable pageable = PageRequest.of(page - 1, size);
+
+    // 스튜디오별 매출 데이터 조회
+    List<AdminStudioSalesData> studioSalesData = paymentRepository.getStudioSalesData(
+        startDateTime, endDateTime, PaymentStatus.PAID, pageable);
+
+    // 전체 스튜디오 수 (페이징용)
+    long totalStudios = paymentRepository.countDistinctStudiosByDateRange(startDateTime, endDateTime);
+
+    return new AdminStudioSalesResponse(
+        start.toString(),
+        end.toString(),
+        studioSalesData,
+        new AdminSalesPaginationResponse(page, totalStudios, (int) Math.ceil((double) totalStudios / size))
+    );
+  }
+
+  /**
+   * 결제 방법별 통계
+   */
+  public AdminPaymentMethodStatsResponse getPaymentMethodStats(String startDate, String endDate) {
+    LocalDate start = startDate != null ? LocalDate.parse(startDate) : LocalDate.now().minusMonths(1);
+    LocalDate end = endDate != null ? LocalDate.parse(endDate) : LocalDate.now();
+    LocalDateTime startDateTime = start.atStartOfDay();
+    LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
+
+    // 결제 방법별 통계 조회
+    List<AdminPaymentMethodData> methodStats = paymentRepository.getPaymentMethodStats(
+        startDateTime, endDateTime, PaymentStatus.PAID);
+
+    // 전체 매출 (비율 계산용)
+    BigDecimal totalSales = paymentRepository.getSalesByDateRangeAndStatus(
+        startDateTime, endDateTime, PaymentStatus.PAID);
+
+    return new AdminPaymentMethodStatsResponse(
+        start.toString(),
+        end.toString(),
+        totalSales != null ? totalSales : BigDecimal.ZERO,
+        methodStats
+    );
+  }
+
+  /**
+   * 환불 통계 및 분석
+   */
+  public AdminRefundStatsResponse getRefundStats(String startDate, String endDate) {
+    LocalDate start = startDate != null ? LocalDate.parse(startDate) : LocalDate.now().minusMonths(1);
+    LocalDate end = endDate != null ? LocalDate.parse(endDate) : LocalDate.now();
+    LocalDateTime startDateTime = start.atStartOfDay();
+    LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
+
+    // 환불 통계
+    BigDecimal totalRefunds = paymentRepository.getSalesByDateRangeAndStatus(
+        startDateTime, endDateTime, PaymentStatus.REFUNDED);
+
+    long refundCount = paymentRepository.countByDateRangeAndStatus(
+        startDateTime, endDateTime, PaymentStatus.REFUNDED);
+
+    // 전체 매출 대비 환불률 계산
+    BigDecimal totalSales = paymentRepository.getSalesByDateRangeAndStatus(
+        startDateTime, endDateTime, PaymentStatus.PAID);
+
+    double refundRate = 0.0;
+    if (totalSales != null && totalSales.compareTo(BigDecimal.ZERO) > 0) {
+      refundRate = totalRefunds.divide(totalSales, 4, BigDecimal.ROUND_HALF_UP)
+          .multiply(BigDecimal.valueOf(100)).doubleValue();
+    }
+
+    // 일별 환불 트렌드
+    List<AdminRefundTrendData> refundTrend = getDailyRefundTrend(start, end);
+
+    return new AdminRefundStatsResponse(
+        start.toString(),
+        end.toString(),
+        totalRefunds != null ? totalRefunds : BigDecimal.ZERO,
+        refundCount,
+        refundRate,
+        refundTrend
+    );
+  }
+
+  /**
+   * 매출 상세 내역 조회
+   */
+  public AdminSalesDetailResponse getSalesDetails(
+      int page, int size, String startDate, String endDate, String method, String status) {
+
+    paginationValidator.validatePaginationParameters(page, size);
+
+    LocalDate start = startDate != null ? LocalDate.parse(startDate) : LocalDate.now().minusMonths(1);
+    LocalDate end = endDate != null ? LocalDate.parse(endDate) : LocalDate.now();
+    LocalDateTime startDateTime = start.atStartOfDay();
+    LocalDateTime endDateTime = end.atTime(LocalTime.MAX);
+
+    Pageable pageable = PageRequest.of(page - 1, size);
+
+    PaymentMethod paymentMethod = method != null ? PaymentMethod.valueOf(method.toUpperCase()) : null;
+    PaymentStatus paymentStatus = status != null ? PaymentStatus.valueOf(status.toUpperCase()) : null;
+
+    // 조건에 따른 결제 내역 조회
+    Page<Payment> paymentsPage = getFilteredPayments(
+        startDateTime, endDateTime, paymentMethod, paymentStatus, pageable);
+
+    List<AdminSalesDetailData> salesDetails = paymentsPage.getContent()
+        .stream()
+        .map(this::toAdminSalesDetailData)
+        .toList();
+
+    return new AdminSalesDetailResponse(
+        start.toString(),
+        end.toString(),
+        salesDetails,
+        new AdminSalesPaginationResponse(page, paymentsPage.getTotalElements(), paymentsPage.getTotalPages())
+    );
+  }
+
+  // Private helper methods
+
+  private List<AdminSalesTrendData> getDailySalesTrend(LocalDate start, LocalDate end) {
+    List<AdminSalesTrendData> trendData = new ArrayList<>();
+    LocalDate current = start;
+
+    while (!current.isAfter(end)) {
+      LocalDateTime dayStart = current.atStartOfDay();
+      LocalDateTime dayEnd = current.atTime(LocalTime.MAX);
+
+      BigDecimal dailySales = paymentRepository.getSalesByDateRangeAndStatus(
+          dayStart, dayEnd, PaymentStatus.PAID);
+
+      trendData.add(new AdminSalesTrendData(
+          current.toString(),
+          dailySales != null ? dailySales : BigDecimal.ZERO
+      ));
+
+      current = current.plusDays(1);
+    }
+
+    return trendData;
+  }
+
+  private List<AdminSalesTrendData> getMonthlySalesTrend(LocalDate start, LocalDate end) {
+    List<AdminSalesTrendData> trendData = new ArrayList<>();
+    LocalDate current = start.withDayOfMonth(1);
+
+    while (!current.isAfter(end)) {
+      LocalDate monthEnd = current.withDayOfMonth(current.lengthOfMonth());
+      LocalDateTime monthStart = current.atStartOfDay();
+      LocalDateTime monthEndTime = monthEnd.atTime(LocalTime.MAX);
+
+      BigDecimal monthlySales = paymentRepository.getSalesByDateRangeAndStatus(
+          monthStart, monthEndTime, PaymentStatus.PAID);
+
+      trendData.add(new AdminSalesTrendData(
+          current.format(DateTimeFormatter.ofPattern("yyyy-MM")),
+          monthlySales != null ? monthlySales : BigDecimal.ZERO
+      ));
+
+      current = current.plusMonths(1);
+    }
+
+    return trendData;
+  }
+
+  private List<AdminSalesTrendData> getYearlySalesTrend(LocalDate start, LocalDate end) {
+    List<AdminSalesTrendData> trendData = new ArrayList<>();
+    LocalDate current = start.withDayOfYear(1);
+
+    while (!current.isAfter(end)) {
+      LocalDate yearEnd = current.withDayOfYear(current.lengthOfYear());
+      LocalDateTime yearStart = current.atStartOfDay();
+      LocalDateTime yearEndTime = yearEnd.atTime(LocalTime.MAX);
+
+      BigDecimal yearlySales = paymentRepository.getSalesByDateRangeAndStatus(
+          yearStart, yearEndTime, PaymentStatus.PAID);
+
+      trendData.add(new AdminSalesTrendData(
+          String.valueOf(current.getYear()),
+          yearlySales != null ? yearlySales : BigDecimal.ZERO
+      ));
+
+      current = current.plusYears(1);
+    }
+
+    return trendData;
+  }
+
+  private List<AdminRefundTrendData> getDailyRefundTrend(LocalDate start, LocalDate end) {
+    List<AdminRefundTrendData> trendData = new ArrayList<>();
+    LocalDate current = start;
+
+    while (!current.isAfter(end)) {
+      LocalDateTime dayStart = current.atStartOfDay();
+      LocalDateTime dayEnd = current.atTime(LocalTime.MAX);
+
+      BigDecimal dailyRefunds = paymentRepository.getSalesByDateRangeAndStatus(
+          dayStart, dayEnd, PaymentStatus.REFUNDED);
+
+      long refundCount = paymentRepository.countByDateRangeAndStatus(
+          dayStart, dayEnd, PaymentStatus.REFUNDED);
+
+      trendData.add(new AdminRefundTrendData(
+          current.toString(),
+          dailyRefunds != null ? dailyRefunds : BigDecimal.ZERO,
+          refundCount
+      ));
+
+      current = current.plusDays(1);
+    }
+
+    return trendData;
+  }
+
+  private Page<Payment> getFilteredPayments(
+      LocalDateTime startDateTime, LocalDateTime endDateTime,
+      PaymentMethod method, PaymentStatus status, Pageable pageable) {
+
+    if (method != null && status != null) {
+      return paymentRepository.findByPaidAtBetweenAndMethodAndStatusOrderByPaidAtDesc(
+          startDateTime, endDateTime, method, status, pageable);
+    } else if (method != null) {
+      return paymentRepository.findByPaidAtBetweenAndMethodOrderByPaidAtDesc(
+          startDateTime, endDateTime, method, pageable);
+    } else if (status != null) {
+      return paymentRepository.findByPaidAtBetweenAndStatusOrderByPaidAtDesc(
+          startDateTime, endDateTime, status, pageable);
+    } else {
+      return paymentRepository.findByPaidAtBetweenOrderByPaidAtDesc(
+          startDateTime, endDateTime, pageable);
+    }
+  }
+
+  private AdminSalesDetailData toAdminSalesDetailData(Payment payment) {
+    return new AdminSalesDetailData(
+        payment.getId(),
+        payment.getOrderId(),
+        payment.getReservation().getUser().getName(),
+        payment.getReservation().getStudio().getName(),
+        payment.getAmount(),
+        payment.getMethod() != null ? payment.getMethod().getValue() : null,
+        payment.getStatus().getValue(),
+        payment.getPaidAt(),
+        payment.getCreatedAt()
+    );
+  }
+}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminPaymentMethodData.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminPaymentMethodData.java
@@ -1,0 +1,17 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import org.example.studiopick.domain.common.enums.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public record AdminPaymentMethodData(
+    PaymentMethod method,
+    BigDecimal totalSales,
+    Long paymentCount
+) {
+  public AdminPaymentMethodData(PaymentMethod method, Number totalSales, Long paymentCount) {
+    this(method,
+        totalSales != null ? new BigDecimal(totalSales.toString()) : BigDecimal.ZERO,
+        paymentCount);
+  }
+}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminPaymentMethodStatsResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminPaymentMethodStatsResponse.java
@@ -1,0 +1,11 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AdminPaymentMethodStatsResponse(
+    String startDate,
+    String endDate,
+    BigDecimal totalSales,
+    List<AdminPaymentMethodData> methodStats
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminRefundStatsResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminRefundStatsResponse.java
@@ -1,0 +1,13 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AdminRefundStatsResponse(
+    String startDate,
+    String endDate,
+    BigDecimal totalRefunds,
+    long refundCount,
+    double refundRate,
+    List<AdminRefundTrendData> refundTrend
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminRefundTrendData.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminRefundTrendData.java
@@ -1,0 +1,9 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+
+public record AdminRefundTrendData(
+    String date,
+    BigDecimal refundAmount,
+    long refundCount
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesDetailData.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesDetailData.java
@@ -1,0 +1,16 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record AdminSalesDetailData(
+    Long paymentId,
+    String orderId,
+    String userName,
+    String studioName,
+    BigDecimal amount,
+    String paymentMethod,
+    String status,
+    LocalDateTime paidAt,
+    LocalDateTime createdAt
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesDetailResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesDetailResponse.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.util.List;
+
+public record AdminSalesDetailResponse(
+    String startDate,
+    String endDate,
+    List<AdminSalesDetailData> salesDetails,
+    AdminSalesPaginationResponse pagination
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesPaginationResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesPaginationResponse.java
@@ -1,0 +1,7 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+public record AdminSalesPaginationResponse(
+    int currentPage,
+    long totalElements,
+    int totalPages
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesStatsResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesStatsResponse.java
@@ -1,0 +1,13 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+
+public record AdminSalesStatsResponse(
+    BigDecimal totalSales,
+    BigDecimal todaySales,
+    BigDecimal thisMonthSales,
+    BigDecimal thisYearSales,
+    BigDecimal totalRefunds,
+    long totalPayments,
+    long totalRefundCount
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesTrendData.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesTrendData.java
@@ -1,0 +1,8 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+
+public record AdminSalesTrendData(
+    String period,
+    BigDecimal sales
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesTrendResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminSalesTrendResponse.java
@@ -1,0 +1,12 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record AdminSalesTrendResponse(
+    String startDate,
+    String endDate,
+    String period,
+    BigDecimal totalSales,
+    List<AdminSalesTrendData> trendData
+) {}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminStudioSalesData.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminStudioSalesData.java
@@ -1,0 +1,19 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import org.example.studiopick.domain.common.enums.PaymentMethod;
+
+import java.math.BigDecimal;
+
+public record AdminStudioSalesData(
+    Long studioId,
+    String studioName,
+    BigDecimal totalSales,
+    Long paymentCount
+) {
+  public AdminStudioSalesData(Long studioId,String studioName, Number totalSales, Long paymentCount) {
+    this(studioId,
+        studioName,
+        totalSales != null ? new BigDecimal(totalSales.toString()) : BigDecimal.ZERO,
+        paymentCount);
+  }
+}

--- a/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminStudioSalesResponse.java
+++ b/src/main/java/org/example/studiopick/application/admin/dto/sales/AdminStudioSalesResponse.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.application.admin.dto.sales;
+
+import java.util.List;
+
+public record AdminStudioSalesResponse(
+    String startDate,
+    String endDate,
+    List<AdminStudioSalesData> studioSales,
+    AdminSalesPaginationResponse pagination
+) {}

--- a/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
+++ b/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
@@ -3,10 +3,11 @@ package org.example.studiopick.config;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
-//@Profile("local")
+@Profile("local")
 @Configuration
 public class EmbeddedRedisConfig {
 

--- a/src/main/java/org/example/studiopick/domain/reservation/Reservation.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/Reservation.java
@@ -48,6 +48,9 @@ public class Reservation extends BaseEntity {
 
     @Column(name = "cancelled_at")
     private LocalDateTime cancelledAt;
+
+    @Column(name = "paid_at") // DB 컬럼명과 맞춰야 함
+    private LocalDateTime paidAt;
     
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -3,13 +3,10 @@ package org.example.studiopick.domain.reservation;
 import org.example.studiopick.domain.common.enums.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface ReservationRepository {
   boolean existsOverlappingReservation(Long studioId, LocalDate date, ReservationStatus status, LocalTime start, LocalTime end);

--- a/src/main/java/org/example/studiopick/infrastructure/payment/JpaPaymentRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/payment/JpaPaymentRepository.java
@@ -1,11 +1,22 @@
 package org.example.studiopick.infrastructure.payment;
 
+import org.example.studiopick.application.admin.dto.sales.AdminPaymentMethodData;
+import org.example.studiopick.application.admin.dto.sales.AdminStudioSalesData;
+import org.example.studiopick.domain.common.enums.PaymentMethod;
+import org.example.studiopick.domain.common.enums.PaymentStatus;
 import org.example.studiopick.domain.payment.Payment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
-public interface JpaPaymentRepository extends JpaRepository<Payment, Long> {
+public interface JpaPaymentRepository extends JpaRepository<Payment, Long>{
 
   /**
    * 결제 키로 결제 정보 조회
@@ -21,4 +32,103 @@ public interface JpaPaymentRepository extends JpaRepository<Payment, Long> {
    * 주문 ID로 결제 정보 조회
    */
   Optional<Payment> findByOrderId(String orderId);
+
+  // ===== 매출 통계 관련 메서드들 =====
+
+  /**
+   * 특정 상태의 전체 매출 조회
+   */
+  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p WHERE p.status = :status")
+  BigDecimal getTotalSalesByStatus(@Param("status") PaymentStatus status);
+
+  /**
+   * 기간별 및 상태별 매출 조회
+   */
+  @Query("SELECT COALESCE(SUM(p.amount), 0) FROM Payment p " +
+         "WHERE p.paidAt BETWEEN :startDate AND :endDate AND p.status = :status")
+  BigDecimal getSalesByDateRangeAndStatus(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("status") PaymentStatus status);
+
+  /**
+   * 특정 상태의 결제 건수 조회
+   */
+  long countByStatus(PaymentStatus status);
+
+  /**
+   * 기간별 및 상태별 결제 건수 조회
+   */
+  @Query("SELECT COUNT(p) FROM Payment p " +
+         "WHERE p.paidAt BETWEEN :startDate AND :endDate AND p.status = :status")
+  long countByDateRangeAndStatus(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("status") PaymentStatus status);
+
+  /**
+   * 스튜디오별 매출 데이터 조회
+   */
+  @Query("SELECT new org.example.studiopick.application.admin.dto.sales.AdminStudioSalesData(" +
+         "s.id, s.name, COALESCE(SUM(p.amount), 0), COUNT(p.id)) " +
+         "FROM Payment p " +
+         "JOIN p.reservation r " +
+         "JOIN r.studio s " +
+         "WHERE p.paidAt BETWEEN :startDate AND :endDate AND p.status = :status " +
+         "GROUP BY s.id, s.name " +
+         "ORDER BY SUM(p.amount) DESC")
+  List<AdminStudioSalesData> getStudioSalesData(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("status") PaymentStatus status,
+      Pageable pageable);
+
+  /**
+   * 기간별 스튜디오 수 조회 (페이징용)
+   */
+  @Query("SELECT COUNT(DISTINCT s.id) FROM Payment p " +
+         "JOIN p.reservation r " +
+         "JOIN r.studio s " +
+         "WHERE p.paidAt BETWEEN :startDate AND :endDate")
+  long countDistinctStudiosByDateRange(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate);
+
+  /**
+   * 결제 방법별 통계 조회
+   */
+  @Query("SELECT new org.example.studiopick.application.admin.dto.sales.AdminPaymentMethodData(" +
+         "p.method, COALESCE(SUM(p.amount), 0), COUNT(p.id)) " +
+         "FROM Payment p " +
+         "WHERE p.paidAt BETWEEN :startDate AND :endDate AND p.status = :status " +
+         "GROUP BY p.method")
+  List<AdminPaymentMethodData> getPaymentMethodStats(
+      @Param("startDate") LocalDateTime startDate,
+      @Param("endDate") LocalDateTime endDate,
+      @Param("status") PaymentStatus status);
+
+  /**
+   * 기간별 결제 내역 조회 (모든 조건)
+   */
+  Page<Payment> findByPaidAtBetweenOrderByPaidAtDesc(
+      LocalDateTime startDate, LocalDateTime endDate, Pageable pageable);
+
+  /**
+   * 기간별 및 결제방법별 결제 내역 조회
+   */
+  Page<Payment> findByPaidAtBetweenAndMethodOrderByPaidAtDesc(
+      LocalDateTime startDate, LocalDateTime endDate, PaymentMethod method, Pageable pageable);
+
+  /**
+   * 기간별 및 상태별 결제 내역 조회
+   */
+  Page<Payment> findByPaidAtBetweenAndStatusOrderByPaidAtDesc(
+      LocalDateTime startDate, LocalDateTime endDate, PaymentStatus status, Pageable pageable);
+
+  /**
+   * 기간별, 결제방법별, 상태별 결제 내역 조회
+   */
+  Page<Payment> findByPaidAtBetweenAndMethodAndStatusOrderByPaidAtDesc(
+      LocalDateTime startDate, LocalDateTime endDate, 
+      PaymentMethod method, PaymentStatus status, Pageable pageable);
 }

--- a/src/main/java/org/example/studiopick/web/admin/AdminSalesController.java
+++ b/src/main/java/org/example/studiopick/web/admin/AdminSalesController.java
@@ -1,0 +1,275 @@
+package org.example.studiopick.web.admin;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studiopick.application.admin.AdminSalesService;
+import org.example.studiopick.application.admin.dto.sales.*;
+import org.example.studiopick.common.dto.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/sales")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminSalesController {
+
+  private final AdminSalesService adminSalesService;
+
+  /**
+   * 전체 매출 통계 조회
+   * GET /api/admin/sales/stats
+   */
+  @GetMapping("/stats")
+  public ResponseEntity<ApiResponse<AdminSalesStatsResponse>> getSalesStats() {
+    log.info("전체 매출 통계 조회 요청");
+
+    AdminSalesStatsResponse response = adminSalesService.getSalesStats();
+
+    ApiResponse<AdminSalesStatsResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "매출 통계를 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 기간별 매출 트렌드 분석
+   * GET /api/admin/sales/trend?startDate=2025-01-01&endDate=2025-01-31&period=daily
+   */
+  @GetMapping("/trend")
+  public ResponseEntity<ApiResponse<AdminSalesTrendResponse>> getSalesTrend(
+      @RequestParam String startDate,
+      @RequestParam String endDate,
+      @RequestParam(defaultValue = "daily") String period
+  ) {
+    log.info("매출 트렌드 분석 요청: startDate={}, endDate={}, period={}",
+        startDate, endDate, period);
+
+    AdminSalesTrendResponse response = adminSalesService.getSalesTrend(startDate, endDate, period);
+
+    ApiResponse<AdminSalesTrendResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "매출 트렌드를 분석했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 스튜디오별 매출 분석
+   * GET /api/admin/sales/studios?page=1&size=10&startDate=2025-01-01&endDate=2025-01-31
+   */
+  @GetMapping("/studios")
+  public ResponseEntity<ApiResponse<AdminStudioSalesResponse>> getStudioSalesAnalysis(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) String startDate,
+      @RequestParam(required = false) String endDate
+  ) {
+    log.info("스튜디오별 매출 분석 요청: page={}, size={}, startDate={}, endDate={}",
+        page, size, startDate, endDate);
+
+    AdminStudioSalesResponse response = adminSalesService.getStudioSalesAnalysis(
+        page, size, startDate, endDate);
+
+    ApiResponse<AdminStudioSalesResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "스튜디오별 매출을 분석했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 결제 방법별 통계
+   * GET /api/admin/sales/payment-methods?startDate=2025-01-01&endDate=2025-01-31
+   */
+  @GetMapping("/payment-methods")
+  public ResponseEntity<ApiResponse<AdminPaymentMethodStatsResponse>> getPaymentMethodStats(
+      @RequestParam(required = false) String startDate,
+      @RequestParam(required = false) String endDate
+  ) {
+    log.info("결제 방법별 통계 요청: startDate={}, endDate={}", startDate, endDate);
+
+    AdminPaymentMethodStatsResponse response = adminSalesService.getPaymentMethodStats(
+        startDate, endDate);
+
+    ApiResponse<AdminPaymentMethodStatsResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "결제 방법별 통계를 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 환불 통계 및 분석
+   * GET /api/admin/sales/refunds?startDate=2025-01-01&endDate=2025-01-31
+   */
+  @GetMapping("/refunds")
+  public ResponseEntity<ApiResponse<AdminRefundStatsResponse>> getRefundStats(
+      @RequestParam(required = false) String startDate,
+      @RequestParam(required = false) String endDate
+  ) {
+    log.info("환불 통계 분석 요청: startDate={}, endDate={}", startDate, endDate);
+
+    AdminRefundStatsResponse response = adminSalesService.getRefundStats(startDate, endDate);
+
+    ApiResponse<AdminRefundStatsResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "환불 통계를 분석했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 매출 상세 내역 조회
+   * GET /api/admin/sales/details?page=1&size=10&startDate=2025-01-01&endDate=2025-01-31&method=card&status=paid
+   */
+  @GetMapping("/details")
+  public ResponseEntity<ApiResponse<AdminSalesDetailResponse>> getSalesDetails(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(required = false) String startDate,
+      @RequestParam(required = false) String endDate,
+      @RequestParam(required = false) String method,
+      @RequestParam(required = false) String status
+  ) {
+    log.info("매출 상세 내역 조회 요청: page={}, size={}, startDate={}, endDate={}, method={}, status={}",
+        page, size, startDate, endDate, method, status);
+
+    AdminSalesDetailResponse response = adminSalesService.getSalesDetails(
+        page, size, startDate, endDate, method, status);
+
+    ApiResponse<AdminSalesDetailResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "매출 상세 내역을 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 오늘 매출 현황 (빠른 접근용)
+   * GET /api/admin/sales/today
+   */
+  @GetMapping("/today")
+  public ResponseEntity<ApiResponse<AdminSalesTrendResponse>> getTodaySales() {
+    log.info("오늘 매출 현황 조회 요청");
+
+    String today = java.time.LocalDate.now().toString();
+    AdminSalesTrendResponse response = adminSalesService.getSalesTrend(today, today, "daily");
+
+    ApiResponse<AdminSalesTrendResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "오늘 매출 현황을 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 이번 달 매출 현황 (빠른 접근용)
+   * GET /api/admin/sales/this-month
+   */
+  @GetMapping("/this-month")
+  public ResponseEntity<ApiResponse<AdminSalesTrendResponse>> getThisMonthSales() {
+    log.info("이번 달 매출 현황 조회 요청");
+
+    java.time.LocalDate now = java.time.LocalDate.now();
+    String startOfMonth = now.withDayOfMonth(1).toString();
+    String endOfMonth = now.withDayOfMonth(now.lengthOfMonth()).toString();
+
+    AdminSalesTrendResponse response = adminSalesService.getSalesTrend(
+        startOfMonth, endOfMonth, "daily");
+
+    ApiResponse<AdminSalesTrendResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "이번 달 매출 현황을 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 이번 년도 월별 매출 트렌드 (빠른 접근용)
+   * GET /api/admin/sales/this-year
+   */
+  @GetMapping("/this-year")
+  public ResponseEntity<ApiResponse<AdminSalesTrendResponse>> getThisYearSales() {
+    log.info("이번 년도 매출 트렌드 조회 요청");
+
+    java.time.LocalDate now = java.time.LocalDate.now();
+    String startOfYear = now.withDayOfYear(1).toString();
+    String endOfYear = now.withDayOfYear(now.lengthOfYear()).toString();
+
+    AdminSalesTrendResponse response = adminSalesService.getSalesTrend(
+        startOfYear, endOfYear, "monthly");
+
+    ApiResponse<AdminSalesTrendResponse> apiResponse = new ApiResponse<>(
+        true,
+        response,
+        "이번 년도 매출 트렌드를 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 매출 요약 대시보드 (빠른 접근용)
+   * GET /api/admin/sales/dashboard
+   */
+  @GetMapping("/dashboard")
+  public ResponseEntity<ApiResponse<AdminSalesDashboardResponse>> getSalesDashboard() {
+    log.info("매출 대시보드 조회 요청");
+
+    // 기본 통계
+    AdminSalesStatsResponse stats = adminSalesService.getSalesStats();
+
+    // 최근 7일 트렌드
+    java.time.LocalDate now = java.time.LocalDate.now();
+    String weekAgo = now.minusDays(6).toString();
+    String today = now.toString();
+    AdminSalesTrendResponse weekTrend = adminSalesService.getSalesTrend(weekAgo, today, "daily");
+
+    // 결제 방법별 통계 (최근 30일)
+    String monthAgo = now.minusDays(29).toString();
+    AdminPaymentMethodStatsResponse methodStats = adminSalesService.getPaymentMethodStats(monthAgo, today);
+
+    AdminSalesDashboardResponse dashboard = new AdminSalesDashboardResponse(
+        stats,
+        weekTrend,
+        methodStats
+    );
+
+    ApiResponse<AdminSalesDashboardResponse> apiResponse = new ApiResponse<>(
+        true,
+        dashboard,
+        "매출 대시보드를 조회했습니다."
+    );
+
+    return ResponseEntity.ok(apiResponse);
+  }
+
+  /**
+   * 대시보드용 응답 DTO (컨트롤러 내부 클래스)
+   */
+  public record AdminSalesDashboardResponse(
+      AdminSalesStatsResponse stats,
+      AdminSalesTrendResponse weekTrend,
+      AdminPaymentMethodStatsResponse methodStats
+  ) {}
+}


### PR DESCRIPTION
# feat: 관리자 매출 통계 및 분석 API 구현

## 🚀 변경 사항
- `JpaPaymentRepository`에 매출 통계용 쿼리 메서드 추가
- `AdminSalesService`에서 매출 분석 비즈니스 로직 구현  
- `AdminSalesController`에 REST API 엔드포인트 구현
- `ReservationRepository`에서 Payment 관련 메서드 분리

## 📊 주요 기능
- **전체 매출 통계 조회**: 오늘/월/년 매출, 환불 금액, 결제 건수
- **기간별 매출 트렌드**: 일별/월별/연별 매출 변화 추이 분석
- **스튜디오별 매출 분석**: 스튜디오 순위별 매출 현황 (페이징 지원)
- **결제 방법별 통계**: 카드/계좌이체 등 결제 수단별 매출 비율
- **환불 통계 분석**: 환불 금액, 환불률, 일별 환불 트렌드
- **매출 상세 내역**: 필터링 및 페이징 지원하는 상세 거래 내역

## 🔧 구현 내용

### > Repository Layer
- `JpaPaymentRepository`에 매출 통계 전용 쿼리 메서드 추가
 - `getTotalSalesByStatus()`: 상태별 전체 매출 집계
 - `getSalesByDateRangeAndStatus()`: 기간/상태별 매출 조회
 - `getStudioSalesData()`: 스튜디오별 매출 데이터 (JOIN 활용)
 - `getPaymentMethodStats()`: 결제 방법별 통계 집계
 - `countByStatus()`, `countByDateRangeAndStatus()`: 건수 통계
- JPQL `@Query` 어노테이션으로 효율적인 집계 쿼리 구현
- `COALESCE` 함수로 NULL 값 안전 처리

### > Service Layer  
- `AdminSalesService`에 6가지 핵심 분석 기능 구현
 - `getSalesStats()`: 종합 매출 현황 대시보드
 - `getSalesTrend()`: 기간별 트렌드 분석 (daily/monthly/yearly)
 - `getStudioSalesAnalysis()`: 스튜디오 순위 분석
 - `getPaymentMethodStats()`: 결제 수단별 분석
 - `getRefundStats()`: 환불 통계 및 환불률 계산
 - `getSalesDetails()`: 상세 거래 내역 조회
- 날짜 범위 기본값 설정 (최근 1개월)
- 환불률 계산 로직 구현

### > Controller Layer
- `AdminSalesController`에 매출 분석 REST API 구현
- `@PreAuthorize("hasRole('ADMIN')")` 관리자 권한 제한
- 일관된 `ApiResponse` 래퍼로 응답 형식 통일
- 편의용 단축 API 제공: `/today`, `/this-month`, `/this-year`
- 대시보드용 통합 API: `/dashboard`

## 📋 API 명세

### 핵심 API 엔드포인트
- `GET /api/admin/sales/stats` - 전체 매출 통계 조회
- `GET /api/admin/sales/trend` - 기간별 매출 트렌드 분석
- `GET /api/admin/sales/studios` - 스튜디오별 매출 순위
- `GET /api/admin/sales/payment-methods` - 결제 방법별 통계  
- `GET /api/admin/sales/refunds` - 환불 통계 및 트렌드
- `GET /api/admin/sales/details` - 매출 상세 내역

### 편의용 API
- `GET /api/admin/sales/today` - 오늘 매출 현황
- `GET /api/admin/sales/this-month` - 이번 달 매출 현황  
- `GET /api/admin/sales/this-year` - 올해 월별 매출 트렌드
- `GET /api/admin/sales/dashboard` - 통합 대시보드 데이터

## 🛠️ 기술적 개선사항

### 도메인 책임 분리
- `ReservationRepository`에서 Payment 관련 메서드 완전 제거
- Payment 도메인 로직을 `JpaPaymentRepository`로 이관
- 각 Repository가 단일 도메인에 대한 명확한 책임만 보유

### 쿼리 최적화
- JOIN을 활용한 연관 엔티티 조회로 N+1 문제 방지
- 집계 함수 활용으로 애플리케이션 레벨 계산 최소화
- 페이징 처리로 대용량 데이터 효율적 조회

## ✅ 참고사항
- 모든 매출 금액은 `BigDecimal` 타입으로 정확한 계산 보장
- 환불률 계산 시 소수점 4자리까지 정밀도 유지
- 페이징 파라미터 검증으로 잘못된 요청 방지
- 관리자 권한 필수로 보안 강화