### PR TITLE
비밀번호 변경 API

### DIFF
--- a/src/main/java/org/example/studiopick/application/user/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/org/example/studiopick/application/user/dto/ChangePasswordRequestDto.java
@@ -1,0 +1,16 @@
+package org.example.studiopick.application.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChangePasswordRequestDto {
+
+    @NotBlank(message = "현재 비밀번호는 필수입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "새 비밀번호는 필수입니다.")
+    private String newPassword;
+}

--- a/src/main/java/org/example/studiopick/application/user/service/UserService.java
+++ b/src/main/java/org/example/studiopick/application/user/service/UserService.java
@@ -136,4 +136,19 @@ public class UserService {
                 .build();
     }
 
+    @Transactional
+    public void changePassword(Long userId, String currentPassword, String newPassword) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("사용자를 찾을 수 없습니다."));
+
+        if (user.getPassword() == null || !passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new IllegalArgumentException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (!isValidPassword(newPassword)) {
+            throw new IllegalArgumentException("비밀번호는 영문, 숫자, 특수문자를 포함한 8자 이상이어야 합니다.");
+        }
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+    }
 }

--- a/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
+++ b/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
@@ -3,11 +3,10 @@ package org.example.studiopick.config;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
-@Profile("local")
+//@Profile("local") // MAC은 이거 주석 풀고 쓰면됨
 @Configuration
 public class EmbeddedRedisConfig {
 

--- a/src/main/java/org/example/studiopick/web/user/UserController.java
+++ b/src/main/java/org/example/studiopick/web/user/UserController.java
@@ -2,6 +2,7 @@ package org.example.studiopick.web.user;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.dto.ChangePasswordRequestDto;
 import org.example.studiopick.application.user.dto.UserProfileResponseDto;
 import org.example.studiopick.application.user.dto.UserProfileUpdateRequestDto;
 import org.example.studiopick.application.user.dto.UserProfileUpdateResponseDto;
@@ -48,4 +49,19 @@ public class UserController {
                 "data", updated
         ));
     }
+
+    @PutMapping("/password")
+    public ResponseEntity<Map<String, Object>> changePassword(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody ChangePasswordRequestDto requestDto
+    ) {
+        Long userId = userPrincipal.getUserId();
+        userService.changePassword(userId, requestDto.getCurrentPassword(), requestDto.getNewPassword());
+
+        return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "비밀번호가 변경되었습니다."
+        ));
+    }
+
 }


### PR DESCRIPTION
### 작업 내용
- 로그인한 사용자가 본인의 비밀번호를 변경할 수 있는 API를 추가했습니다.
- 현재 비밀번호 일치 여부 확인 후, 새 비밀번호로 업데이트합니다.
- 비밀번호 형식 유효성도 서버에서 검증합니다.

### 주요 변경 사항
- `UserService`: `changePassword(Long, String, String)` 메소드 추가
- `User`: `updatePassword(String)` 메서드 활용
- `ChangePasswordRequestDto` 생성
- `UserController`: `/api/users/password` 엔드포인트 추가 (PUT)

### 요청 예시
```json
{
  "currentPassword": "OldPassword123!",
  "newPassword": "NewPassword456!"
}
