### PR TITLE
프로필 이미지 S3 업로드 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation group: 'it.ozimov', name: 'embedded-redis', version: '0.7.2'
     implementation 'io.netty:netty-resolver-dns-native-macos:4.1.109.Final:osx-aarch_64'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/example/studiopick/config/S3Config.java
+++ b/src/main/java/org/example/studiopick/config/S3Config.java
@@ -1,0 +1,36 @@
+package org.example.studiopick.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(Regions.fromName(region))
+                .withCredentials(
+                        new AWSStaticCredentialsProvider(
+                                new BasicAWSCredentials(accessKey, secretKey)
+                        )
+                )
+                .build();
+    }
+}
+

--- a/src/main/java/org/example/studiopick/domain/user/entity/User.java
+++ b/src/main/java/org/example/studiopick/domain/user/entity/User.java
@@ -42,6 +42,9 @@ public class User extends BaseEntity {
     @Column(name = "email_verified", nullable = false)
     private Boolean emailVerified = false;
 
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     private UserStatus status = UserStatus.ACTIVE;
@@ -58,8 +61,8 @@ public class User extends BaseEntity {
                 Boolean isStudioOwner, UserStatus status, UserRole role) {
         this.email = email;
         this.password = password;
-        this.name = name != null ? name : "소셜회원"; // ✅ 기본값
-        this.phone = phone != null ? phone : "00000000000"; // ✅ 기본값
+        this.name = name != null ? name : "소셜회원"; // 기본값
+        this.phone = phone != null ? phone : "00000000000"; // 기본값
         this.nickname = nickname;
         this.isStudioOwner = isStudioOwner != null ? isStudioOwner : false;
         this.status = status != null ? status : UserStatus.ACTIVE;
@@ -99,6 +102,10 @@ public class User extends BaseEntity {
 
     public void changeRole(UserRole role) {
         this.role = role;
+    }
+
+    public void updateProfileImage(String imageUrl){
+        this.profileImageUrl = imageUrl;
     }
 
     // 관리자용 업데이트 메서드

--- a/src/main/java/org/example/studiopick/infrastructure/s3/S3Uploader.java
+++ b/src/main/java/org/example/studiopick/infrastructure/s3/S3Uploader.java
@@ -1,0 +1,36 @@
+package org.example.studiopick.infrastructure.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+
+    private final AmazonS3 amazonS3;
+    private final String bucket = "studio-pick"; // 버킷 이름 하드코딩 or yml에서 주입 가능
+
+    public String upload(MultipartFile file, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID(); // 예: profile/uuid
+        String fileUrl = "https://" + bucket + ".s3.ap-northeast-2.amazonaws.com/" + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+
+        try {
+            amazonS3.putObject(bucket, fileName, file.getInputStream(), metadata);
+        } catch (IOException e) {
+            throw new RuntimeException("S3 파일 업로드 실패: " + e.getMessage());
+        }
+
+        return fileUrl;
+    }
+}
+

--- a/src/main/java/org/example/studiopick/web/user/UserController.java
+++ b/src/main/java/org/example/studiopick/web/user/UserController.java
@@ -8,9 +8,11 @@ import org.example.studiopick.application.user.dto.UserProfileUpdateRequestDto;
 import org.example.studiopick.application.user.dto.UserProfileUpdateResponseDto;
 import org.example.studiopick.application.user.service.UserService;
 import org.example.studiopick.security.UserPrincipal;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -61,6 +63,20 @@ public class UserController {
         return ResponseEntity.ok(Map.of(
                 "success", true,
                 "message", "비밀번호가 변경되었습니다."
+        ));
+    }
+
+    @PostMapping(value = "/profile/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Map<String, Object>> uploadProfileImage(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @RequestPart("image") MultipartFile image
+    ) {
+        String imageUrl = userService.uploadProfileImage(userPrincipal.getUserId(), image);
+
+        return ResponseEntity.ok(Map.of(
+                "success", true,
+                "message", "프로필 이미지가 업로드되었습니다",
+                "data", Map.of("imageUrl", imageUrl)
         ));
     }
 


### PR DESCRIPTION
### 작업 개요
- 사용자 프로필 이미지 업로드 기능을 구현했습니다.
- S3에 업로드된 이미지 URL을 `User` 엔티티에 저장하고, 응답으로 반환합니다.

---

### 주요 변경 사항
- `S3Uploader` 클래스 생성 및 AWS SDK 연동
- `S3Config`에서 `AmazonS3` 빈 등록 (`application.yml` 기반)
- `User` 엔티티에 `profileImageUrl` 필드 추가
- `UserService`에 `uploadProfileImage()` 메서드 구현
- `UserController`에 `/api/users/profile/image` POST 엔드포인트 추가

---

###  요청 방식
- **Method**: `POST`
- **URL**: `/api/users/profile/image`
- **인증**: `Authorization: Bearer {JWT}`
- **FormData**:
  - `image`: File

---

### 🎯 응답 예시
```json
{
  "success": true,
  "message": "프로필 이미지가 업로드되었습니다",
  "data": {
    "imageUrl": "https://studio-pick.s3.ap-northeast-2.amazonaws.com/profile/uuid.jpg"
  }
}
