### PR TITLE
좋아요/댓글 CRUD API

### DIFF
--- a/src/main/java/org/example/studiopick/application/user/service/UserService.java
+++ b/src/main/java/org/example/studiopick/application/user/service/UserService.java
@@ -31,6 +31,11 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final S3Uploader s3Uploader;
 
+    public User getById(Long id) {
+        return userRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+    }
+
     @Transactional
     public void signup(UserSignupRequestDto dto) {
         if (userRepository.findByEmail(dto.getEmail()).isPresent()) {

--- a/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkCommentRequestDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkCommentRequestDto.java
@@ -1,0 +1,12 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ArtworkCommentRequestDto {
+
+    private String comment;
+
+}

--- a/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkCommentResponseDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkCommentResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ArtworkCommentResponseDto {
+    private Long id;
+    private String comment;
+    private String nickname;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkDetailResponseDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkDetailResponseDto.java
@@ -1,0 +1,23 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class ArtworkDetailResponseDto {
+    private Long id;
+    private String title;
+    private String description;
+    private String imageUrl;
+
+    private SimpleUserDto user; // 작성자
+    private SimpleStudioDto studio; // 소속 스튜디오
+
+    private int likeCount;
+    private boolean isLiked;
+
+    private List<ArtworkCommentResponseDto> comments;  // 댓글 목록
+}

--- a/src/main/java/org/example/studiopick/common/dto/artwork/SimpleStudioDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/SimpleStudioDto.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimpleStudioDto {
+    private String name;
+}

--- a/src/main/java/org/example/studiopick/common/dto/artwork/SimpleUserDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/SimpleUserDto.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SimpleUserDto {
+    private String nickname;
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkComment.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkComment.java
@@ -1,0 +1,41 @@
+package org.example.studiopick.domain.artwork;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.example.studiopick.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "artwork_comment")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArtworkComment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artwork_id", nullable = false)
+    private Artwork artwork;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 300)
+    private String comment;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    private LocalDateTime updatedAt;
+
+    public void updateComment(String newComment) {
+        this.comment = newComment;
+    }
+
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkCommentRepository.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkCommentRepository.java
@@ -1,0 +1,11 @@
+package org.example.studiopick.domain.artwork;
+
+import org.example.studiopick.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ArtworkCommentRepository extends JpaRepository<ArtworkComment, Long> {
+    List<ArtworkComment> findByArtwork(Artwork artwork);
+    List<ArtworkComment> findByUser(User user);
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkCommentService.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkCommentService.java
@@ -1,0 +1,94 @@
+package org.example.studiopick.domain.artwork;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.common.dto.artwork.ArtworkCommentResponseDto;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArtworkCommentService {
+
+    private final ArtworkRepository artworkRepository;
+    private final ArtworkCommentRepository artworkCommentRepository;
+
+    @Transactional
+    public ArtworkCommentResponseDto createComment(Long artworkId, User user, String commentText) {
+        Artwork artwork = artworkRepository.findById(artworkId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 작품이 존재하지 않습니다."));
+
+        ArtworkComment comment = ArtworkComment.builder()
+                .artwork(artwork)
+                .user(user)
+                .comment(commentText)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        ArtworkComment saved = artworkCommentRepository.save(comment);
+
+        return ArtworkCommentResponseDto.builder()
+                .id(saved.getId())
+                .comment(saved.getComment())
+                .nickname(saved.getUser().getNickname())
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<ArtworkCommentResponseDto> getCommentsByArtworkId(Long artworkId) {
+        Artwork artwork = artworkRepository.findById(artworkId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 작품이 존재하지 않습니다."));
+
+        return artworkCommentRepository.findByArtwork(artwork).stream()
+                .map(comment -> ArtworkCommentResponseDto.builder()
+                        .id(comment.getId())
+                        .comment(comment.getComment())
+                        .nickname(comment.getUser().getNickname())
+                        .createdAt(comment.getCreatedAt())
+                        .build())
+                .toList();
+    }
+
+    @Transactional
+    public ArtworkCommentResponseDto updateComment(Long artworkId, Long commentId, User user, String newComment) {
+        ArtworkComment comment = artworkCommentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+        if (!comment.getArtwork().getId().equals(artworkId)) {
+            throw new IllegalArgumentException("댓글이 해당 작품에 속하지 않습니다.");
+        }
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("본인의 댓글만 수정할 수 있습니다.");
+        }
+
+        comment.updateComment(newComment); // setter 대신 update 메서드 활용
+        return ArtworkCommentResponseDto.builder()
+                .id(comment.getId())
+                .comment(comment.getComment())
+                .nickname(comment.getUser().getNickname())
+                .createdAt(comment.getCreatedAt())
+                .build();
+    }
+
+    @Transactional
+    public void deleteComment(Long artworkId, Long commentId, User user) {
+        ArtworkComment comment = artworkCommentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글이 존재하지 않습니다."));
+
+        if (!comment.getArtwork().getId().equals(artworkId)) {
+            throw new IllegalArgumentException("댓글이 해당 작품에 속하지 않습니다.");
+        }
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new SecurityException("본인의 댓글만 삭제할 수 있습니다.");
+        }
+
+        artworkCommentRepository.delete(comment);
+    }
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkLike.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkLike.java
@@ -1,0 +1,33 @@
+package org.example.studiopick.domain.artwork;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.example.studiopick.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "artwork_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"artwork_id", "user_id"})})
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArtworkLike {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "artwork_id", nullable = false)
+    private Artwork artwork;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+
+    private User user;
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkLikeRepository.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkLikeRepository.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.domain.artwork;
+
+import org.example.studiopick.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtworkLikeRepository extends JpaRepository<ArtworkLike, Long> {
+    boolean existsByArtworkAndUser(Artwork artwork, User user);
+    int countByArtwork(Artwork artwork);
+    void deleteByArtworkAndUser(Artwork artwork, User user);
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkLikeService.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkLikeService.java
@@ -1,0 +1,33 @@
+package org.example.studiopick.domain.artwork;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ArtworkLikeService {
+
+    private final ArtworkRepository artworkRepository;
+    private final ArtworkLikeRepository artworkLikeRepository;
+
+    @Transactional
+    public void toggleLike(Long artworkId, User user) {
+        Artwork artwork = artworkRepository.findById(artworkId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 작품이 존재하지 않습니다."));
+
+        boolean alreadyLiked = artworkLikeRepository.existsByArtworkAndUser(artwork, user);
+
+        if (alreadyLiked) {
+            artworkLikeRepository.deleteByArtworkAndUser(artwork, user);
+        } else {
+            ArtworkLike like = ArtworkLike.builder()
+                    .artwork(artwork)
+                    .user(user)
+                    .build();
+            artworkLikeRepository.save(like);
+        }
+    }
+}

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
@@ -1,7 +1,9 @@
 package org.example.studiopick.domain.artwork;
 
 import lombok.RequiredArgsConstructor;
-import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
+import org.example.studiopick.common.dto.artwork.*;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
 import org.example.studiopick.infrastructure.mybatis.ArtworkMapper;
 import org.springframework.stereotype.Service;
 
@@ -10,10 +12,56 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class ArtworkService {
-
+    // Mapper (피드 정렬 조회용)
     private final ArtworkMapper artworkMapper;
 
+    // Repository (상세조회용)
+    private final ArtworkRepository artworkRepository;
+    private final ArtworkCommentRepository artworkCommentRepository;
+    private final ArtworkLikeRepository artworkLikeRepository;
+
+    // 작품 피드 조회
     public List<ArtworkFeedDto> getArtworks(String sort, int offset, int limit, String hashtags) {
         return artworkMapper.findAllSorted(sort, offset, limit, hashtags);
     }
+
+    // === 작품 상세 조회 ===
+    public ArtworkDetailResponseDto getArtworkDetail(Long artworkId, User user) {
+        // 1. 작품 가져오기
+        Artwork artwork = artworkRepository.findById(artworkId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 작품이 존재하지 않습니다."));
+
+        // 2. 댓글 목록 가져오기
+        List<ArtworkComment> commentEntities = artworkCommentRepository.findByArtwork(artwork);
+        List<ArtworkCommentResponseDto> comments = commentEntities.stream()
+                .map(c -> ArtworkCommentResponseDto.builder()
+                        .id(c.getId())
+                        .comment(c.getComment())
+                        .nickname(c.getUser().getNickname())
+                        .createdAt(c.getCreatedAt())
+                        .build())
+                .toList();
+
+        // 3. 좋아요 수 / 사용자 좋아요 여부
+        int likeCount = artworkLikeRepository.countByArtwork(artwork);
+        boolean isLiked = artworkLikeRepository.existsByArtworkAndUser(artwork, user);
+
+        // 4. 응답 DTO 구성
+        return ArtworkDetailResponseDto.builder()
+                .id(artwork.getId())
+                .title(artwork.getTitle())
+                .description(artwork.getDescription())
+                .imageUrl(artwork.getImageUrl())
+                .user(SimpleUserDto.builder()
+                        .nickname(artwork.getUser().getNickname())
+                        .build())
+                .studio(SimpleStudioDto.builder()
+                        .name(artwork.getStudio().getName())
+                        .build())
+                .likeCount(likeCount)
+                .isLiked(isLiked)
+                .comments(comments)
+                .build();
+    }
 }
+

--- a/src/main/java/org/example/studiopick/security/UserPrincipal.java
+++ b/src/main/java/org/example/studiopick/security/UserPrincipal.java
@@ -16,6 +16,10 @@ public class UserPrincipal implements OAuth2User, UserDetails {
     private final User user;
     private Map<String, Object> attributes;
 
+    public Long getId() {
+        return user.getId();
+    }
+
     public UserPrincipal(User user) {
         this.user = user;
     }

--- a/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
+++ b/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
@@ -1,15 +1,17 @@
 package org.example.studiopick.web.user;
 
 import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.service.UserService;
 import org.example.studiopick.common.dto.ApiResponse;
+import org.example.studiopick.common.dto.artwork.ArtworkDetailResponseDto;
 import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
 import org.example.studiopick.domain.artwork.Artwork;
 import org.example.studiopick.domain.artwork.ArtworkService;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.security.UserPrincipal;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +23,7 @@ import java.util.Map;
 public class ArtWorkController {
 
     private final ArtworkService artworkService;
+    private final UserService userService;
 
     @GetMapping
     public ResponseEntity<ApiResponse<Map<String, Object>>> getArtworks(
@@ -36,5 +39,14 @@ public class ArtWorkController {
         result.put("artworks", artworks);
 
         return ResponseEntity.ok(new ApiResponse<>(true, result, null));
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<ApiResponse<ArtworkDetailResponseDto>> getArtworkById(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        User user = userService.getById(userPrincipal.getId());
+        ArtworkDetailResponseDto detail = artworkService.getArtworkDetail(id, user);
+        return ResponseEntity.ok(new ApiResponse<>(true, detail, null));
     }
 }

--- a/src/main/java/org/example/studiopick/web/user/ArtworkCommentController.java
+++ b/src/main/java/org/example/studiopick/web/user/ArtworkCommentController.java
@@ -1,0 +1,68 @@
+package org.example.studiopick.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.service.UserService;
+import org.example.studiopick.common.dto.artwork.ArtworkCommentRequestDto;
+import org.example.studiopick.common.dto.artwork.ArtworkCommentResponseDto;
+import org.example.studiopick.domain.artwork.ArtworkCommentService;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.security.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class ArtworkCommentController {
+    private final ArtworkCommentService artworkCommentService;
+    private final UserService userService;
+
+    @PostMapping("/api/artworks/{artworkId}/comments")
+    public ResponseEntity<ArtworkCommentResponseDto> addComment(
+            @PathVariable Long artworkId,
+            @RequestBody ArtworkCommentRequestDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        User user = userService.getById(userPrincipal.getId()); // 로그인 유저 정보
+        ArtworkCommentResponseDto response =
+                artworkCommentService.createComment(artworkId, user, request.getComment());
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/api/artworks/{artworkId}/comments")
+    public ResponseEntity<List<ArtworkCommentResponseDto>> getComments(
+            @PathVariable Long artworkId) {
+
+        List<ArtworkCommentResponseDto> comments = artworkCommentService.getCommentsByArtworkId(artworkId);
+        return ResponseEntity.ok(comments);
+    }
+
+    @PutMapping("/api/artworks/{artworkId}/comments/{commentId}")
+    public ResponseEntity<ArtworkCommentResponseDto> updateComment(
+            @PathVariable Long artworkId,
+            @PathVariable Long commentId,
+            @RequestBody ArtworkCommentRequestDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        User user = userService.getById(userPrincipal.getId());
+        ArtworkCommentResponseDto updated =
+                artworkCommentService.updateComment(artworkId, commentId, user, request.getComment());
+
+        return ResponseEntity.ok(updated);
+    }
+
+    @DeleteMapping("/api/artworks/{artworkId}/comments/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long artworkId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        User user = userService.getById(userPrincipal.getId());
+        artworkCommentService.deleteComment(artworkId, commentId, user);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/org/example/studiopick/web/user/ArtworkLikeController.java
+++ b/src/main/java/org/example/studiopick/web/user/ArtworkLikeController.java
@@ -1,0 +1,30 @@
+package org.example.studiopick.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.user.service.UserService;
+import org.example.studiopick.domain.artwork.ArtworkLikeService;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.security.UserPrincipal;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class ArtworkLikeController {
+
+    private final ArtworkLikeService artworkLikeService;
+    private final UserService userService;
+
+    @PostMapping("/api/artworks/{artworkId}/like")
+    public ResponseEntity<Void> toggleLike(
+            @PathVariable Long artworkId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        User user = userService.getById(userPrincipal.getId());
+        artworkLikeService.toggleLike(artworkId, user);
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
구현 내용
좋아요 기능

POST /api/artworks/{id}/like : 좋아요 토글 (좋아요/취소)

댓글 기능

POST /api/artworks/{id}/comments : 댓글 작성

GET /api/artworks/{id}/comments : 댓글 조회

PUT /api/artworks/{id}/comments/{commentId} : 댓글 수정

DELETE /api/artworks/{id}/comments/{commentId} : 댓글 삭제

작품 상세 조회 시 포함된 기능

댓글 목록, 좋아요 수, 로그인 사용자의 좋아요 여부 포함 응답

🧪 테스트 방법
Postman으로 API 테스트

Swagger 연동 예정 (현재 작업 중)