### PR TITLE
신고 처리 API #34

### DIFF
--- a/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
+++ b/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
@@ -3,10 +3,11 @@ package org.example.studiopick.config;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
-//@Profile("local") // MAC은 이거 주석 풀고 쓰면됨
+@Profile("local") // MAC은 이거 주석 풀고 쓰면됨
 @Configuration
 public class EmbeddedRedisConfig {
 

--- a/src/main/java/org/example/studiopick/domain/report/ReportRepository.java
+++ b/src/main/java/org/example/studiopick/domain/report/ReportRepository.java
@@ -1,0 +1,13 @@
+package org.example.studiopick.domain.report;
+
+import org.example.studiopick.domain.common.enums.ReportStatus;
+import org.example.studiopick.domain.common.enums.ReportType;
+import org.example.studiopick.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+
+public interface ReportRepository extends JpaRepository<Report, Long> {
+
+    boolean existsByUserAndReportedTypeAndReportedId(User user, ReportType reportedType, Long reportedId);
+    long countByReportedTypeAndReportedIdAndStatus(ReportType reportedType, Long reportedId, ReportStatus status);
+}

--- a/src/main/java/org/example/studiopick/domain/report/ReportService.java
+++ b/src/main/java/org/example/studiopick/domain/report/ReportService.java
@@ -1,0 +1,54 @@
+package org.example.studiopick.domain.report;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.domain.common.enums.ReportStatus;
+import org.example.studiopick.domain.common.enums.ReportType;
+import org.example.studiopick.domain.report.dto.ReportRequestDto;
+import org.example.studiopick.domain.report.dto.ReportResponseDto;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ReportService{
+
+    private final ReportRepository reportRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReportResponseDto createReport(Long userId, ReportRequestDto request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 정보를 찾을 수 없습니다."));
+
+        boolean alreadyReported = reportRepository.existsByUserAndReportedTypeAndReportedId(
+                user, request.reportedType(), request.reportedId());
+
+        if (alreadyReported) {
+            throw new IllegalStateException("이미 신고하셨습니다.");
+        }
+
+        Report report = Report.builder()
+                .reportedType(request.reportedType())
+                .reportedId(request.reportedId())
+                .user(user)
+                .reason(request.reason())
+                .build();
+
+        reportRepository.save(report);
+
+        // 자동 비공개 처리 로직 (신고 3회 이상이면)
+        long reportCount = reportRepository.countByReportedTypeAndReportedIdAndStatus(
+                request.reportedType(), request.reportedId(), ReportStatus.PENDING
+        );
+
+        if (reportCount >= 3) {
+            report.autoHide();
+            // TODO: 실제로 Artwork, Class, Review 상태 비공개 처리도 함께 해야 함
+        }
+
+        return new ReportResponseDto(report.getId(), "신고가 접수되었습니다.");
+    }
+
+}

--- a/src/main/java/org/example/studiopick/domain/report/dto/ReportRequestDto.java
+++ b/src/main/java/org/example/studiopick/domain/report/dto/ReportRequestDto.java
@@ -1,0 +1,17 @@
+package org.example.studiopick.domain.report.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.example.studiopick.domain.common.enums.ReportType;
+
+public record ReportRequestDto (
+        @NotNull(message = "신고 유형은 필수입니다.")
+        ReportType reportedType,
+
+        @NotNull(message = "신고 대상 ID는 필수입니다.")
+        Long reportedId,
+
+        @NotBlank(message = "신고 사유를 입력해주세요.")
+        String reason
+
+) {}

--- a/src/main/java/org/example/studiopick/domain/report/dto/ReportResponseDto.java
+++ b/src/main/java/org/example/studiopick/domain/report/dto/ReportResponseDto.java
@@ -1,0 +1,6 @@
+package org.example.studiopick.domain.report.dto;
+
+public record ReportResponseDto(
+        Long reportId,
+        String message
+) {}

--- a/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
@@ -10,7 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface UserRepository {
+public interface UserRepository extends JpaRepository<User, Long> {
 
   // 일반 로그인 및 중복검사
   Optional<User> findByEmail(String email);

--- a/src/main/java/org/example/studiopick/web/user/ReportController.java
+++ b/src/main/java/org/example/studiopick/web/user/ReportController.java
@@ -1,0 +1,25 @@
+package org.example.studiopick.web.user;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.domain.report.ReportService;
+import org.example.studiopick.domain.report.dto.ReportRequestDto;
+import org.example.studiopick.domain.report.dto.ReportResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user/reports")
+@RequiredArgsConstructor
+public class ReportController {
+
+    private final ReportService reportService;
+
+    @PostMapping
+    public ResponseEntity<ReportResponseDto> createReport(
+            @RequestHeader("X-USER-ID") Long userId,
+            @RequestBody ReportRequestDto request
+    ) {
+        ReportResponseDto response = reportService.createReport(userId, request);
+        return ResponseEntity.ok(response);
+    }
+}


### PR DESCRIPTION
✅ 신고 처리 API 구현 (USER014)
/api/reports POST 엔드포인트 추가

작품/클래스/리뷰 신고 기능 처리

로그인한 사용자만 신고 가능

동일 대상 중복 신고 방지

신고 3회 이상 시 autoHide() 처리 적용

📝 테스트
인텔리J 기준 정상 동작 확인

토큰 인증 로직 제외 후 기능 확인

Redis: local profile 주석 해제하여 실행

⚠️ 추후 보완 예정
알림(Notification) 연동

비로그인 접근 차단 및 예외 처리 정리

신고 대상별 실제 콘텐츠 상태 변경 로직 연동