### PR TITLE
대시보드 통계 데이터 API

### DIFF
--- a/src/main/java/org/example/studiopick/application/studio/dto/DashboardResponseDto.java
+++ b/src/main/java/org/example/studiopick/application/studio/dto/DashboardResponseDto.java
@@ -1,0 +1,16 @@
+package org.example.studiopick.application.studio.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DashboardResponseDto {
+
+    private long todayReservationCount;      // 오늘 예약 수
+    private long monthReservationCount;      // 이번 달 예약 수
+    private long todayRevenue;               // 오늘 매출
+    private long monthRevenue;               // 이번 달 매출
+    private long newCustomerCount;           // 신규 고객 수
+    private long classCount;                 // 클래스 수
+}

--- a/src/main/java/org/example/studiopick/application/studio/service/DashboardService.java
+++ b/src/main/java/org/example/studiopick/application/studio/service/DashboardService.java
@@ -1,0 +1,56 @@
+package org.example.studiopick.application.studio.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.DashboardResponseDto;
+import org.example.studiopick.domain.reservation.ReservationRepository;
+import org.example.studiopick.domain.user.repository.UserRepository;
+import org.example.studiopick.domain.studio.repository.DashboardClassRepository;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+    private final DashboardClassRepository classRepository;
+
+    public DashboardResponseDto getStudioDashboard(Long studioId) {
+        LocalDate today = LocalDate.now();
+        YearMonth currentMonth = YearMonth.now();
+        LocalDate monthStart = currentMonth.atDay(1);
+        LocalDate monthEnd = currentMonth.atEndOfMonth();
+
+        // 예약 수
+        long todayReservationCount = reservationRepository.countByReservationDateBetween(today, today);
+        long monthReservationCount = reservationRepository.countByReservationDateBetween(monthStart, monthEnd);
+
+        // 매출
+        long todayRevenue = reservationRepository
+                .sumTotalAmountByReservationDate(today) != null ?
+                reservationRepository.sumTotalAmountByReservationDate(today) : 0L;
+
+        long monthRevenue = reservationRepository
+                .sumTotalAmountByReservationDateBetween(monthStart, monthEnd) != null ?
+                reservationRepository.sumTotalAmountByReservationDateBetween(monthStart, monthEnd) : 0L;
+
+        // 신규 고객 (이번 달 가입)
+        long newCustomerCount = userRepository.countByCreatedAtBetween(monthStart.atStartOfDay(), monthEnd.atTime(23, 59, 59));
+
+        // 클래스 수
+        long classCount = classRepository.countByStudioId(studioId);
+
+        return DashboardResponseDto.builder()
+                .todayReservationCount(todayReservationCount)
+                .monthReservationCount(monthReservationCount)
+                .todayRevenue(todayRevenue)
+                .monthRevenue(monthRevenue)
+                .newCustomerCount(newCustomerCount)
+                .classCount(classCount)
+                .build();
+    }
+}
+

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -3,6 +3,7 @@ package org.example.studiopick.domain.reservation;
 import org.example.studiopick.domain.common.enums.ReservationStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -46,4 +47,18 @@ public interface ReservationRepository {
   // 스튜디오별 조회
   Page<Reservation> findByStudioIdOrderByReservationDateDesc(Long studioId, Pageable pageable);
   Page<Reservation> findByStudioIdAndStatusOrderByReservationDateDesc(Long studioId, ReservationStatus status, Pageable pageable);
+
+  // 이번 달 예약 수
+  long countByReservationDateBetween(LocalDate startDate, LocalDate endDate);
+
+  // 오늘 매출 합계
+  // 전체 Reservation 중 날짜가 같은 것의 totalAmount를 SUM
+  @Query("SELECT SUM(r.totalAmount) FROM Reservation r WHERE r.reservationDate = :date")
+  Long sumTotalAmountByReservationDate(LocalDate date);
+
+  // 이번 달 매출 합계
+  // 특정 기간 내 totalAmount의 SUM
+  @Query("SELECT SUM(r.totalAmount) FROM Reservation r WHERE r.reservationDate BETWEEN :start AND :end")
+  Long sumTotalAmountByReservationDateBetween(LocalDate startDate, LocalDate endDate);
+
 }

--- a/src/main/java/org/example/studiopick/domain/studio/repository/DashboardClassRepository.java
+++ b/src/main/java/org/example/studiopick/domain/studio/repository/DashboardClassRepository.java
@@ -1,0 +1,9 @@
+package org.example.studiopick.domain.studio.repository;
+
+import org.example.studiopick.domain.class_entity.ClassEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DashboardClassRepository extends JpaRepository<ClassEntity, Long> {
+
+    long countByStudioId(Long studioId);
+}

--- a/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
+++ b/src/main/java/org/example/studiopick/domain/user/repository/UserRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -44,4 +45,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   Page<User> findByStatusAndNameContainingIgnoreCaseOrderByCreatedAtDesc(
       UserStatus status, String name, Pageable pageable);
+
+  long countByCreatedAtBetween(LocalDateTime start, LocalDateTime end);
+
 }

--- a/src/main/java/org/example/studiopick/web/studio/DashboardController.java
+++ b/src/main/java/org/example/studiopick/web/studio/DashboardController.java
@@ -1,0 +1,22 @@
+package org.example.studiopick.web.studio;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.DashboardResponseDto;
+import org.example.studiopick.application.studio.service.DashboardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studio/dashboard")
+public class DashboardController {
+
+    private final DashboardService dashboardService;
+
+    // 대시보드 통계 조회 API
+    @GetMapping
+    public ResponseEntity<DashboardResponseDto> getDashboard(@RequestParam Long studioId) {
+        DashboardResponseDto dashboard = dashboardService.getStudioDashboard(studioId);
+        return ResponseEntity.ok(dashboard);
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 스튜디오 관리자용 대시보드 통계 API 구현
- 통계 항목:
  - 오늘 예약 수
  - 이번 달 예약 수
  - 오늘 매출
  - 이번 달 매출
  - 이번 달 신규 고객 수
  - 클래스 수

## 관련 파일

- `DashboardResponseDto.java`
- `DashboardService.java`
- `DashboardController.java`
- `ReservationRepository.java`: 통계용 쿼리 메서드(@Query) 추가
- `UserRepository.java`, `DashboardClassRepository.java`: 카운트 메서드 추가

## 테스트

- Swagger에서 API 노출 확인
- 권한 문제로 실 호출 테스트는 추후 관리자 승인 구조와 함께 적용 예정
