### PR TITLE
스튜디오별 예약 조회 API

### DIFF
--- a/src/main/java/org/example/studiopick/application/studio/dto/StudioReservationResponseDto.java
+++ b/src/main/java/org/example/studiopick/application/studio/dto/StudioReservationResponseDto.java
@@ -1,0 +1,22 @@
+package org.example.studiopick.application.studio.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class StudioReservationResponseDto {
+
+    private Long reservationId;
+    private String userName;
+    private String userPhone;
+    private LocalDate reservationDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private Short peopleCount;
+    private String status;
+    private Long totalAmount;
+}
+

--- a/src/main/java/org/example/studiopick/application/studio/service/StudioReservationService.java
+++ b/src/main/java/org/example/studiopick/application/studio/service/StudioReservationService.java
@@ -1,0 +1,41 @@
+package org.example.studiopick.application.studio.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.StudioReservationResponseDto;
+import org.example.studiopick.domain.reservation.Reservation;
+import org.example.studiopick.domain.reservation.ReservationRepository;
+import org.example.studiopick.domain.common.enums.ReservationStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudioReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    public List<StudioReservationResponseDto> getReservations(Long studioId, LocalDate date, String status, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        ReservationStatus statusEnum = ReservationStatus.valueOf(status.toUpperCase());
+
+        Page<Reservation> reservationPage = reservationRepository
+                .findByStudioIdAndReservationDateAndStatus(studioId, date, statusEnum, pageRequest);
+
+        return reservationPage.map(reservation -> StudioReservationResponseDto.builder()
+                .reservationId(reservation.getId())
+                .userName(reservation.getUser().getName())
+                .userPhone(reservation.getUser().getPhone())
+                .reservationDate(reservation.getReservationDate())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .peopleCount(reservation.getPeopleCount())
+                .status(reservation.getStatus().name())
+                .totalAmount(reservation.getTotalAmount())
+                .build()).toList();
+    }
+}

--- a/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
+++ b/src/main/java/org/example/studiopick/domain/reservation/ReservationRepository.java
@@ -61,4 +61,11 @@ public interface ReservationRepository {
   @Query("SELECT SUM(r.totalAmount) FROM Reservation r WHERE r.reservationDate BETWEEN :start AND :end")
   Long sumTotalAmountByReservationDateBetween(LocalDate startDate, LocalDate endDate);
 
+  Page<Reservation> findByStudioIdAndReservationDateAndStatus(
+          Long studioId,
+          LocalDate reservationDate,
+          ReservationStatus status,
+          Pageable pageable
+  );
+
 }

--- a/src/main/java/org/example/studiopick/web/studio/StudioReservationController.java
+++ b/src/main/java/org/example/studiopick/web/studio/StudioReservationController.java
@@ -1,0 +1,33 @@
+package org.example.studiopick.web.studio;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.StudioReservationResponseDto;
+import org.example.studiopick.application.studio.service.StudioReservationService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studio/reservations")
+public class StudioReservationController {
+
+    private final StudioReservationService studioReservationService;
+
+    @GetMapping
+    public ResponseEntity<List<StudioReservationResponseDto>> getReservations(
+            @RequestParam Long studioId,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        List<StudioReservationResponseDto> reservations =
+                studioReservationService.getReservations(studioId, date, status, page, size);
+        return ResponseEntity.ok(reservations);
+    }
+}
+


### PR DESCRIPTION
##  작업 내용

- 스튜디오 관리자가 날짜/상태 기준으로 예약 목록을 조회할 수 있는 API 구현
- 페이징, 예약 상태 필터 포함
- Swagger에서 API 정상 노출 및 시큐리티에 따라 401 응답 정상 확인

## 주요 사항

- 경로: `GET /api/studio/reservations`
- 파라미터:
  - `studioId`: Long
  - `date`: LocalDate (`yyyy-MM-dd`)
  - `status`: 예약 상태 (`CONFIRMED`, `PENDING`, `CANCELLED` 등)
  - `page`, `size`: 페이징

##  추가 구성

- `StudioReservationResponseDto` 생성
- `StudioReservationService` 구현
- `StudioReservationController` 작성
- `ReservationRepository`에 페이징 쿼리 메서드 추가

##  테스트

- Swagger에서 401 Unauthorized 발생 → 인증 정책 정상 반영 확인
- 추후 프론트 연동 시 JWT 토큰 포함 필요
