### PR TITLE
클래스 CRUD API

### DIFF
--- a/src/main/java/org/example/studiopick/application/studio/dto/StudioClassRequestDto.java
+++ b/src/main/java/org/example/studiopick/application/studio/dto/StudioClassRequestDto.java
@@ -1,0 +1,23 @@
+package org.example.studiopick.application.studio.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Setter
+public class StudioClassRequestDto {
+
+    private Long studioId;          // 어떤 스튜디오의 클래스인지
+    private String title;           // 클래스명
+    private String description;     // 설명
+    private BigDecimal price;       // 가격
+    private LocalDate date;         // 날짜
+    private LocalTime startTime;    // 시작 시간
+    private LocalTime endTime;      // 종료 시간
+    private String instructor;      // 강사명
+    private String status;          // 상태 (OPEN, CLOSED)
+}
+

--- a/src/main/java/org/example/studiopick/application/studio/dto/StudioClassResponseDto.java
+++ b/src/main/java/org/example/studiopick/application/studio/dto/StudioClassResponseDto.java
@@ -1,0 +1,23 @@
+package org.example.studiopick.application.studio.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@Builder
+public class StudioClassResponseDto {
+
+    private Long classId;
+    private String title;
+    private String description;
+    private BigDecimal price;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private String instructor;
+    private String status;
+}

--- a/src/main/java/org/example/studiopick/application/studio/service/StudioClassService.java
+++ b/src/main/java/org/example/studiopick/application/studio/service/StudioClassService.java
@@ -1,0 +1,80 @@
+package org.example.studiopick.application.studio.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.StudioClassRequestDto;
+import org.example.studiopick.application.studio.dto.StudioClassResponseDto;
+import org.example.studiopick.domain.class_entity.ClassEntity;
+import org.example.studiopick.domain.class_entity.StudioClassRepository;
+import org.example.studiopick.domain.common.enums.ClassStatus;
+import org.example.studiopick.domain.studio.Studio;
+import org.example.studiopick.domain.studio.repository.StudioClassJpaRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StudioClassService {
+
+    private final StudioClassRepository classRepository;
+    private final StudioClassJpaRepository jpaStudioRepository;
+
+    // 클래스 등록
+    @Transactional
+    public Long createClass(StudioClassRequestDto dto) {
+        Studio studio = jpaStudioRepository.findById(dto.getStudioId())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 스튜디오입니다."));
+
+        ClassEntity classEntity = ClassEntity.builder()
+                .studio(studio)
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .price(dto.getPrice())
+                .date(dto.getDate())
+                .startTime(dto.getStartTime())
+                .endTime(dto.getEndTime())
+                .instructor(dto.getInstructor())
+                .status(ClassStatus.valueOf(dto.getStatus()))
+                .build();
+
+        return classRepository.save(classEntity).getId();
+    }
+
+    // 클래스 전체 조회 (스튜디오 기준)
+    @Transactional(readOnly = true)
+    public List<StudioClassResponseDto> getClassesByStudio(Long studioId) {
+        return classRepository.findByStudioId(studioId)
+                .stream()
+                .map(classEntity -> StudioClassResponseDto.builder()
+                        .classId(classEntity.getId())
+                        .title(classEntity.getTitle())
+                        .description(classEntity.getDescription())
+                        .price(classEntity.getPrice())
+                        .date(classEntity.getDate())
+                        .startTime(classEntity.getStartTime())
+                        .endTime(classEntity.getEndTime())
+                        .instructor(classEntity.getInstructor())
+                        .status(classEntity.getStatus().name())
+                        .build())
+                .toList();
+    }
+
+    // 클래스 수정
+    @Transactional
+    public void updateClass(Long classId, StudioClassRequestDto dto) {
+        ClassEntity classEntity = classRepository.findById(classId)
+                .orElseThrow(() -> new IllegalArgumentException("클래스를 찾을 수 없습니다."));
+
+        classEntity.updateBasicInfo(dto.getTitle(), dto.getDescription(), dto.getPrice());
+        classEntity.updateSchedule(dto.getDate(), dto.getStartTime(), dto.getEndTime());
+        classEntity.changeStatus(ClassStatus.valueOf(dto.getStatus()));
+    }
+
+    // 클래스 삭제
+    @Transactional
+    public void deleteClass(Long classId) {
+        classRepository.deleteById(classId);
+    }
+}
+

--- a/src/main/java/org/example/studiopick/domain/class_entity/StudioClassRepository.java
+++ b/src/main/java/org/example/studiopick/domain/class_entity/StudioClassRepository.java
@@ -1,0 +1,11 @@
+package org.example.studiopick.domain.class_entity;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StudioClassRepository extends JpaRepository<ClassEntity, Long> {
+
+    // 스튜디오 ID로 클래스 목록 조회
+    List<ClassEntity> findByStudioId(Long studioId);
+}

--- a/src/main/java/org/example/studiopick/domain/studio/repository/StudioClassJpaRepository.java
+++ b/src/main/java/org/example/studiopick/domain/studio/repository/StudioClassJpaRepository.java
@@ -1,0 +1,8 @@
+package org.example.studiopick.domain.studio.repository;
+
+import org.example.studiopick.domain.studio.Studio;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudioClassJpaRepository extends JpaRepository<Studio, Long> {
+}
+

--- a/src/main/java/org/example/studiopick/web/studio/StudioClassController.java
+++ b/src/main/java/org/example/studiopick/web/studio/StudioClassController.java
@@ -1,0 +1,46 @@
+package org.example.studiopick.web.studio;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.studio.dto.StudioClassRequestDto;
+import org.example.studiopick.application.studio.dto.StudioClassResponseDto;
+import org.example.studiopick.application.studio.service.StudioClassService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studio/classes")
+public class StudioClassController {
+
+    private final StudioClassService studioClassService;
+
+    // 클래스 등록
+    @PostMapping
+    public ResponseEntity<Long> createClass(@RequestBody StudioClassRequestDto dto) {
+        Long classId = studioClassService.createClass(dto);
+        return ResponseEntity.ok(classId);
+    }
+
+    // 클래스 목록 조회 (스튜디오 ID 기준)
+    @GetMapping
+    public ResponseEntity<List<StudioClassResponseDto>> getClasses(@RequestParam Long studioId) {
+        List<StudioClassResponseDto> classes = studioClassService.getClassesByStudio(studioId);
+        return ResponseEntity.ok(classes);
+    }
+
+    // 클래스 수정
+    @PutMapping("/{classId}")
+    public ResponseEntity<Void> updateClass(@PathVariable Long classId, @RequestBody StudioClassRequestDto dto) {
+        studioClassService.updateClass(classId, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 클래스 삭제
+    @DeleteMapping("/{classId}")
+    public ResponseEntity<Void> deleteClass(@PathVariable Long classId) {
+        studioClassService.deleteClass(classId);
+        return ResponseEntity.ok().build();
+    }
+}


### PR DESCRIPTION
## 작업 내용

- 스튜디오 관리자가 사용하는 클래스 등록/조회/수정/삭제 API 구현
- Spring Data JPA 기반 CRUD 처리
- Swagger 연동 완료 (Security 적용되어 토큰 없을 경우 401 반환 확인됨)

## API 경로

| 메서드 | URL | 설명 |
|--------|-----|------|
| POST | `/api/studio/classes` | 클래스 등록 |
| GET  | `/api/studio/classes?studioId=1` | 클래스 목록 조회 |
| PUT  | `/api/studio/classes/{classId}` | 클래스 수정 |
| DELETE | `/api/studio/classes/{classId}` | 클래스 삭제 |

## 주요 구성 파일

- `StudioClassRequestDto`, `StudioClassResponseDto`
- `StudioClassService`
- `StudioClassController`
- `StudioClassRepository` (기존 클래스 레포지토리 충돌 방지)
- `StudioClassJpaRepository` (StudioRepository와 Bean 충돌 방지용 별도 JPA repo 생성)

## 테스트

- Swagger에서 요청 확인
- 인증이 필요한 API는 401 반환 정상 확인됨 (토큰 적용 시 테스트 가능)
