### PR TITLE
고객 관리 및 통게 API

### DIFF
--- a/src/main/java/org/example/studiopick/StudioPickApplication.java
+++ b/src/main/java/org/example/studiopick/StudioPickApplication.java
@@ -10,7 +10,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 @MapperScan({
         "org.example.studiopick.infrastructure.reservation.mybatis",
         "org.example.studiopick.infrastructure.statistics",
-        "org.example.studiopick.infrastructure.artwork.mybatis"
+        "org.example.studiopick.infrastructure.artwork.mybatis",
+        "org.example.studiopick.infrastructure.customer.mapper"
 })
 public class StudioPickApplication {
 

--- a/src/main/java/org/example/studiopick/application/customer/dto/FrequentCustomerDto.java
+++ b/src/main/java/org/example/studiopick/application/customer/dto/FrequentCustomerDto.java
@@ -1,0 +1,20 @@
+package org.example.studiopick.application.customer.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FrequentCustomerDto {
+    private Long userId;
+    private String name;
+    private String phone;
+    private LocalDate lastVisitDate;
+    private Integer visitCount;
+}

--- a/src/main/java/org/example/studiopick/application/customer/service/CustomerQueryService.java
+++ b/src/main/java/org/example/studiopick/application/customer/service/CustomerQueryService.java
@@ -1,0 +1,19 @@
+package org.example.studiopick.application.customer.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.customer.dto.FrequentCustomerDto;
+import org.example.studiopick.infrastructure.customer.mapper.CustomerMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerQueryService {
+
+    private final CustomerMapper customerMapper;
+
+    public List<FrequentCustomerDto> getFrequentCustomers(String keyword) {
+        return customerMapper.findFrequentCustomers(keyword);
+    }
+}

--- a/src/main/java/org/example/studiopick/infrastructure/customer/mapper/CustomerMapper.java
+++ b/src/main/java/org/example/studiopick/infrastructure/customer/mapper/CustomerMapper.java
@@ -1,0 +1,14 @@
+package org.example.studiopick.infrastructure.customer.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.example.studiopick.application.customer.dto.FrequentCustomerDto;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+@Mapper
+public interface CustomerMapper {
+
+    List<FrequentCustomerDto> findFrequentCustomers(@Param("keyword") String keyword);
+
+}

--- a/src/main/java/org/example/studiopick/web/customer/CustomerController.java
+++ b/src/main/java/org/example/studiopick/web/customer/CustomerController.java
@@ -1,0 +1,26 @@
+package org.example.studiopick.web.customer;
+
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.customer.dto.FrequentCustomerDto;
+import org.example.studiopick.application.customer.service.CustomerQueryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/customers")
+@RequiredArgsConstructor
+public class CustomerController {
+
+    private final CustomerQueryService customerQueryService;
+
+    @GetMapping("/frequent")
+    public List<FrequentCustomerDto> getFrequentCustomers(
+            @RequestParam(required = false) String keyword
+    ) {
+        return customerQueryService.getFrequentCustomers(keyword);
+    }
+}

--- a/src/main/resources/mappers/customer/CustomerMapper.xml
+++ b/src/main/resources/mappers/customer/CustomerMapper.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="org.example.studiopick.infrastructure.customer.mapper.CustomerMapper">
+
+    <select id="findFrequentCustomers"
+            resultType="org.example.studiopick.application.customer.dto.FrequentCustomerDto">
+        SELECT
+        u.id AS userId,
+        u.name,
+        u.phone,
+        MAX(r.reservation_date) AS lastVisitDate,
+        COUNT(r.id) AS visitCount
+        FROM user u
+        JOIN reservation r ON u.id = r.user_id
+        WHERE u.status = 'ACTIVE'
+        <if test="keyword != null and keyword != ''">
+            AND (u.name ILIKE CONCAT('%', #{keyword}, '%') OR u.phone ILIKE CONCAT('%', #{keyword}, '%'))
+        </if>
+        GROUP BY u.id, u.name, u.phone
+        ORDER BY lastVisitDate DESC
+    </select>
+
+</mapper>


### PR DESCRIPTION
###  작업 목적
- 스튜디오 운영자가 단골 고객 정보를 빠르게 확인할 수 있도록
- 최근 예약일 기준으로 자주 오는 고객을 조회할 수 있는 API 제공

---

###  주요 기능
- 단골 고객 조회 API: `GET /api/customers/frequent`
- 이름/전화번호 기반 검색 가능 (`keyword` 파라미터)
- 예약이 존재하는 고객만 조회됨
- 최근 예약일 기준 내림차순 정렬
- `status = 'ACTIVE'`인 사용자만 포함

---

###  구현 내역
- `FrequentCustomerDto` 생성 (`application.customer.dto`)
- `CustomerMapper.xml` 작성 및 SQL 정의
- `CustomerMapper` 인터페이스 추가
- `CustomerQueryService` 생성
- `CustomerController`에 GET API 추가