### PR TITLE
작품 이미지 S3 업로드 API 그외 2개

### DIFF
--- a/src/main/java/org/example/studiopick/application/user/service/UserService.java
+++ b/src/main/java/org/example/studiopick/application/user/service/UserService.java
@@ -31,6 +31,7 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final S3Uploader s3Uploader;
 
+
     public User getById(Long id) {
         return userRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));

--- a/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkUploadRequestDto.java
+++ b/src/main/java/org/example/studiopick/common/dto/artwork/ArtworkUploadRequestDto.java
@@ -1,0 +1,17 @@
+package org.example.studiopick.common.dto.artwork;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ArtworkUploadRequestDto {
+    private String title;
+    private String description;
+    private String hashtags;
+    private String shootingDate;
+    private String shootingLocation;
+    private Long studioId;
+    private Boolean isPublic;
+    private List<String> imageUrls;
+}

--- a/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
+++ b/src/main/java/org/example/studiopick/config/EmbeddedRedisConfig.java
@@ -7,8 +7,8 @@ import org.springframework.context.annotation.Profile;
 import redis.embedded.RedisServer;
 
 import java.io.IOException;
-@Profile("local") // MAC은 이거 주석 풀고 쓰면됨
-@Configuration
+//@Profile("local") // MAC은 이거 주석 풀고 쓰면됨
+//@Configuration
 public class EmbeddedRedisConfig {
 
     private RedisServer redisServer;

--- a/src/main/java/org/example/studiopick/domain/artwork/Artwork.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/Artwork.java
@@ -33,6 +33,14 @@ public class Artwork extends BaseEntity {
     
     @Column(name = "hashtags", length = 255)
     private String hashtags;
+
+    // [추가] 촬영일자
+    @Column(name = "shooting_date")
+    private String shootingDate;
+
+    // [추가] 촬영장소
+    @Column(name = "shooting_location", length = 255)
+    private String shootingLocation;
     
     @Column(name = "is_public", nullable = false)
     private Boolean isPublic = true;
@@ -52,7 +60,8 @@ public class Artwork extends BaseEntity {
     
     @Builder
     public Artwork(User user, Studio studio, String title, String description, String imageUrl, 
-                   String hashtags, Boolean isPublic, ArtworkStatus status) {
+                   String hashtags, Boolean isPublic, ArtworkStatus status,
+                   String shootingDate, String shootingLocation) {
         this.user = user;
         this.studio = studio;
         this.title = title;
@@ -61,6 +70,8 @@ public class Artwork extends BaseEntity {
         this.hashtags = hashtags;
         this.isPublic = isPublic != null ? isPublic : true;
         this.status = status != null ? status : ArtworkStatus.PUBLIC;
+        this.shootingDate = shootingDate;               // [추가]
+        this.shootingLocation = shootingLocation;       // [추가]
     }
     
     public void updateBasicInfo(String title, String description, String hashtags) {
@@ -119,5 +130,17 @@ public class Artwork extends BaseEntity {
         } else {
             throw new IllegalArgumentException("순서는 0 이상의 숫자여야 합니다.");
         }
+
+    }
+
+    public void update(String title, String description, String hashtags,
+                       String shootingDate, String shootingLocation, String imageUrl, Boolean isPublic) {
+        this.title = title;
+        this.description = description;
+        this.hashtags = hashtags;
+        this.shootingDate = shootingDate;
+        this.shootingLocation = shootingLocation;
+        this.imageUrl = imageUrl;
+        this.isPublic = isPublic != null && isPublic;
     }
 }

--- a/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
+++ b/src/main/java/org/example/studiopick/domain/artwork/ArtworkService.java
@@ -2,36 +2,49 @@ package org.example.studiopick.domain.artwork;
 
 import lombok.RequiredArgsConstructor;
 import org.example.studiopick.common.dto.artwork.*;
+import org.example.studiopick.domain.common.enums.ArtworkStatus;
+import org.example.studiopick.domain.studio.Studio;
+import org.example.studiopick.infrastructure.studio.JpaStudioRepository;
 import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.domain.user.repository.UserRepository;
 import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
 import org.example.studiopick.infrastructure.artwork.mybatis.ArtworkMapper;
+import org.example.studiopick.infrastructure.s3.S3Uploader;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class ArtworkService {
-    // Mapper (피드 정렬 조회용)
+
+    // ✅ S3 업로더
+    private final S3Uploader s3Uploader;
+
+    // ✅ 피드 정렬용 Mapper
     private final ArtworkMapper artworkMapper;
 
-    // Repository (상세조회용)
+    // ✅ Repository들
     private final ArtworkRepository artworkRepository;
     private final ArtworkCommentRepository artworkCommentRepository;
     private final ArtworkLikeRepository artworkLikeRepository;
 
-    // 작품 피드 조회
+    // ✅ studio 저장소 → JpaStudioRepository로 변경 완료
+    private final JpaStudioRepository studioRepository;
+
+    private final UserRepository userRepository;
+
+    // ✅ 작품 피드 조회
     public List<ArtworkFeedDto> getArtworks(String sort, int offset, int limit, String hashtags) {
         return artworkMapper.findAllSorted(sort, offset, limit, hashtags);
     }
 
-    // === 작품 상세 조회 ===
+    // ✅ 작품 상세 조회
     public ArtworkDetailResponseDto getArtworkDetail(Long artworkId, User user) {
-        // 1. 작품 가져오기
         Artwork artwork = artworkRepository.findById(artworkId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 작품이 존재하지 않습니다."));
 
-        // 2. 댓글 목록 가져오기
         List<ArtworkComment> commentEntities = artworkCommentRepository.findByArtwork(artwork);
         List<ArtworkCommentResponseDto> comments = commentEntities.stream()
                 .map(c -> ArtworkCommentResponseDto.builder()
@@ -42,11 +55,9 @@ public class ArtworkService {
                         .build())
                 .toList();
 
-        // 3. 좋아요 수 / 사용자 좋아요 여부
         int likeCount = artworkLikeRepository.countByArtwork(artwork);
         boolean isLiked = artworkLikeRepository.existsByArtworkAndUser(artwork, user);
 
-        // 4. 응답 DTO 구성
         return ArtworkDetailResponseDto.builder()
                 .id(artwork.getId())
                 .title(artwork.getTitle())
@@ -63,5 +74,62 @@ public class ArtworkService {
                 .comments(comments)
                 .build();
     }
-}
 
+    // ✅ S3 업로드 기능
+    public String uploadToS3(MultipartFile file) {
+        return s3Uploader.upload(file, "artworks");
+    }
+
+    // ✅ 작품 저장 기능
+    public Long saveArtwork(ArtworkUploadRequestDto dto, Long userId) {
+        Studio studio = studioRepository.findById(dto.getStudioId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 스튜디오가 존재하지 않습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+
+        Artwork artwork = Artwork.builder()
+                .title(dto.getTitle())
+                .description(dto.getDescription())
+                .hashtags(dto.getHashtags())
+                .shootingDate(dto.getShootingDate())
+                .shootingLocation(dto.getShootingLocation())
+                .studio(studio)
+                .user(user)
+                .imageUrl(dto.getImageUrls().get(0)) // 대표 이미지
+                .isPublic(dto.getIsPublic() != null && dto.getIsPublic())
+                .status(ArtworkStatus.PUBLIC)
+                .build();
+
+        artworkRepository.save(artwork);
+        return artwork.getId();
+    }
+
+    // 작품 수정
+    public void updateArtwork(Long artworkId, Long userId, ArtworkUploadRequestDto dto) {
+        Artwork artwork = artworkRepository.findByIdAndUserId(artworkId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("작품을 수정할 권한이 없습니다."));
+
+        artwork.update(
+                dto.getTitle(),
+                dto.getDescription(),
+                dto.getHashtags(),
+                dto.getShootingDate(),
+                dto.getShootingLocation(),
+                dto.getImageUrls() != null && !dto.getImageUrls().isEmpty() ? dto.getImageUrls().get(0) : artwork.getImageUrl(),
+                dto.getIsPublic()
+        );
+
+        artworkRepository.save(artwork);
+    }
+
+    // 작품 삭제
+    public void deleteArtwork(Long artworkId, Long userId) {
+        Artwork artwork = artworkRepository.findByIdAndUserId(artworkId, userId)
+                .orElseThrow(() -> new IllegalArgumentException("작품을 삭제할 권한이 없습니다."));
+
+        artworkRepository.delete(artwork);
+    }
+
+
+}

--- a/src/main/java/org/example/studiopick/infrastructure/artwork/ArtworkRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/artwork/ArtworkRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ArtworkRepository extends JpaRepository<Artwork, Long> {
   List<Artwork> findByStudioId(Long studioId);
+
+  Optional<Artwork> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
+++ b/src/main/java/org/example/studiopick/web/user/ArtWorkController.java
@@ -5,14 +5,18 @@ import org.example.studiopick.application.user.service.UserService;
 import org.example.studiopick.common.dto.ApiResponse;
 import org.example.studiopick.common.dto.artwork.ArtworkDetailResponseDto;
 import org.example.studiopick.common.dto.artwork.ArtworkFeedDto;
+import org.example.studiopick.common.dto.artwork.ArtworkUploadRequestDto;
 import org.example.studiopick.domain.artwork.Artwork;
 import org.example.studiopick.domain.artwork.ArtworkService;
 import org.example.studiopick.domain.user.entity.User;
 import org.example.studiopick.security.UserPrincipal;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,4 +53,78 @@ public class ArtWorkController {
         ArtworkDetailResponseDto detail = artworkService.getArtworkDetail(id, user);
         return ResponseEntity.ok(new ApiResponse<>(true, detail, null));
     }
+
+    // 1. 이미지 업로드 API
+    @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<Map<String, Object>>> uploadArtworkImages(
+            @RequestPart("images") MultipartFile[] images) {
+
+        if (images.length > 10) {
+            throw new IllegalArgumentException("최대 10장의 이미지만 업로드 가능합니다.");
+        }
+
+        List<String> uploadedUrls = new ArrayList<>();
+        for (MultipartFile file : images) {
+            validateImageFile(file); // 용량/확장자 검사
+            String url = artworkService.uploadToS3(file); // 내부에서 S3Uploader 호출
+            uploadedUrls.add(url);
+        }
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("imageUrls", uploadedUrls);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, result, null));
+    }
+
+    // 2. 작품 저장 API
+    @PostMapping
+    public ResponseEntity<ApiResponse<Map<String, Object>>> uploadArtwork(
+            @RequestBody ArtworkUploadRequestDto dto,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        Long userId = userPrincipal.getUserId();
+        Long artworkId = artworkService.saveArtwork(dto, userId); // 저장 후 ID 반환
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("artworkId", artworkId);
+
+        return ResponseEntity.ok(new ApiResponse<>(true, result, "작품이 업로드되었습니다."));
+    }
+
+    // 3. 이미지 유효성 검사 메서드
+    private void validateImageFile(MultipartFile file) {
+        long maxSize = 10 * 1024 * 1024; // 10MB
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException("이미지 용량은 10MB를 초과할 수 없습니다.");
+        }
+
+        String contentType = file.getContentType();
+        if (contentType == null ||
+                !(contentType.equals("image/jpeg") || contentType.equals("image/png") || contentType.equals("image/webp"))) {
+            throw new IllegalArgumentException("이미지 형식은 jpg, png, webp만 허용됩니다.");
+        }
+    }
+
+    // 4. 작품 수정 API
+    @PutMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> updateArtwork(
+            @PathVariable Long id,
+            @RequestBody ArtworkUploadRequestDto dto,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        artworkService.updateArtwork(id, userPrincipal.getUserId(), dto);
+        return ResponseEntity.ok(new ApiResponse<>(true, null, "작품이 수정되었습니다."));
+    }
+
+    // 5. 작품 삭제 API
+    @DeleteMapping("/{id}")
+    public ResponseEntity<ApiResponse<Void>> deleteArtwork(
+            @PathVariable Long id,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+
+        artworkService.deleteArtwork(id, userPrincipal.getUserId());
+        return ResponseEntity.ok(new ApiResponse<>(true, null, "작품이 삭제되었습니다."));
+    }
+
+
 }


### PR DESCRIPTION
- studio-pick #29: 이미지 S3 업로드 API 구현
- studio-pick #30: 이미지 용량 및 확장자 검증 로직 추가
- studio-pick #31: 작품 메타데이터 저장 API 구현 (title, desc, 공개여부 등)