### PR TITLE
feat:관리자 신고 관리 api

### DIFF
--- a/src/main/java/org/example/studiopick/domain/class_entity/ClassEntity.java
+++ b/src/main/java/org/example/studiopick/domain/class_entity/ClassEntity.java
@@ -99,6 +99,23 @@ public class ClassEntity extends BaseEntity {
         return this.status == ClassStatus.CLOSED;
     }
     
+    public void report() {
+        this.status = ClassStatus.REPORTED;
+    }
+    
+    public void restore() {
+        this.status = ClassStatus.OPEN;
+    }
+    
+    public boolean isReported() {
+        return this.status == ClassStatus.REPORTED;
+    }
+    
+    public boolean isAvailableForReservation() {
+        return this.status == ClassStatus.OPEN && this.date != null && 
+               this.date.isAfter(LocalDate.now().minusDays(1));
+    }
+    
     public boolean isValidTimeRange() {
         return startTime != null && endTime != null && startTime.isBefore(endTime);
     }

--- a/src/main/java/org/example/studiopick/domain/common/enums/ClassStatus.java
+++ b/src/main/java/org/example/studiopick/domain/common/enums/ClassStatus.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ClassStatus {
     OPEN("open"),
-    CLOSED("closed");
+    CLOSED("closed"),
+    REPORTED("reported");
 
     private final String value;
 

--- a/src/main/java/org/example/studiopick/domain/common/enums/ReviewStatus.java
+++ b/src/main/java/org/example/studiopick/domain/common/enums/ReviewStatus.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum ReviewStatus {
     VISIBLE("visible"),
     HIDDEN("hidden"),
-    DELETED("deleted");
+    DELETED("deleted"),
+    REPORTED("reported");
 
     private final String value;
 

--- a/src/main/java/org/example/studiopick/domain/report/ReportRepository.java
+++ b/src/main/java/org/example/studiopick/domain/report/ReportRepository.java
@@ -5,9 +5,29 @@ import org.example.studiopick.domain.common.enums.ReportType;
 import org.example.studiopick.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
 
+    // 중복 신고 확인
     boolean existsByUserAndReportedTypeAndReportedId(User user, ReportType reportedType, Long reportedId);
+    
+    // 특정 상태의 신고 횟수 조회
     long countByReportedTypeAndReportedIdAndStatus(ReportType reportedType, Long reportedId, ReportStatus status);
+    
+    // 총 신고 횟수 조회 (모든 상태 포함)
+    long countByReportedTypeAndReportedId(ReportType reportedType, Long reportedId);
+    
+    // 특정 컨텐츠에 대한 모든 신고 조회
+    List<Report> findByReportedTypeAndReportedIdOrderByCreatedAtDesc(ReportType reportedType, Long reportedId);
+    
+    // 관리자용: 처리 대기 중인 신고 목록 조회
+    List<Report> findByStatusOrderByCreatedAtDesc(ReportStatus status);
+    
+    // 관리자용: 사용자별 신고 목록 조회
+    List<Report> findByUserOrderByCreatedAtDesc(User user);
+    
+    // 관리자용: 신고 타입별 목록 조회
+    List<Report> findByReportedTypeOrderByCreatedAtDesc(ReportType reportedType);
 }

--- a/src/main/java/org/example/studiopick/domain/report/ReportService.java
+++ b/src/main/java/org/example/studiopick/domain/report/ReportService.java
@@ -1,21 +1,30 @@
 package org.example.studiopick.domain.report;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.studiopick.domain.common.enums.ReportStatus;
 import org.example.studiopick.domain.common.enums.ReportType;
 import org.example.studiopick.domain.report.dto.ReportRequestDto;
 import org.example.studiopick.domain.report.dto.ReportResponseDto;
+import org.example.studiopick.domain.report.service.AutoHideService;
 import org.example.studiopick.domain.user.entity.User;
 import org.example.studiopick.domain.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-public class ReportService{
+@Slf4j
+public class ReportService {
 
     private final ReportRepository reportRepository;
     private final UserRepository userRepository;
+    private final AutoHideService autoHideService;
+    
+    // 자동 비공개 처리를 위한 신고 임계값 (application.yml에서 설정 가능)
+    @Value("${app.report.auto-hide-threshold:3}")
+    private int autoHideThreshold;
 
     @Transactional
     public ReportResponseDto createReport(Long userId, ReportRequestDto request){
@@ -37,18 +46,82 @@ public class ReportService{
                 .build();
 
         reportRepository.save(report);
+        log.info("Report created - Type: {}, ID: {}, User: {}", 
+                request.reportedType(), request.reportedId(), userId);
 
-        // 자동 비공개 처리 로직 (신고 3회 이상이면)
+        // 자동 비공개 처리 로직
         long reportCount = reportRepository.countByReportedTypeAndReportedIdAndStatus(
                 request.reportedType(), request.reportedId(), ReportStatus.PENDING
         );
 
-        if (reportCount >= 3) {
-            report.autoHide();
-            // TODO: 실제로 Artwork, Class, Review 상태 비공개 처리도 함께 해야 함
+        if (reportCount >= autoHideThreshold) {
+            // 자동 비공개 처리
+            boolean hideSuccess = autoHideService.autoHideContent(
+                    request.reportedType(), request.reportedId());
+            
+            if (hideSuccess) {
+                report.autoHide();
+                reportRepository.save(report);
+                log.warn("Content auto-hidden - Type: {}, ID: {}, Report Count: {}", 
+                        request.reportedType(), request.reportedId(), reportCount);
+                
+                return new ReportResponseDto(report.getId(), 
+                        "신고가 접수되었습니다. 신고 횟수가 " + autoHideThreshold + "회에 도달하여 해당 콘텐츠가 자동으로 비공개 처리되었습니다.");
+            } else {
+                log.error("Failed to auto-hide content - Type: {}, ID: {}", 
+                         request.reportedType(), request.reportedId());
+            }
         }
 
         return new ReportResponseDto(report.getId(), "신고가 접수되었습니다.");
     }
-
+    
+    /**
+     * 관리자가 신고를 처리할 때 사용하는 메서드
+     */
+    @Transactional
+    public void processReport(Long reportId, Long adminId, ReportStatus status, String adminComment) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new IllegalArgumentException("신고를 찾을 수 없습니다."));
+        
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new IllegalArgumentException("관리자 정보를 찾을 수 없습니다."));
+        
+        // 신고 상태에 따른 처리
+        switch (status) {
+            case REVIEWED:
+                report.markAsReviewed(admin, adminComment);
+                break;
+            case RESTORED:
+                report.restore(admin, adminComment);
+                // 컨텐츠 복원
+                autoHideService.restoreContent(report.getReportedType(), report.getReportedId());
+                break;
+            case DELETED:
+                report.delete(admin, adminComment);
+                // 컨텐츠 영구 삭제는 별도 로직 필요
+                break;
+            default:
+                throw new IllegalArgumentException("유효하지 않은 신고 처리 상태입니다.");
+        }
+        
+        reportRepository.save(report);
+        log.info("Report processed - ID: {}, Status: {}, Admin: {}", reportId, status, adminId);
+    }
+    
+    /**
+     * 신고 상태별 카운트 조회
+     */
+    @Transactional(readOnly = true)
+    public long getReportCount(ReportType reportType, Long reportedId, ReportStatus status) {
+        return reportRepository.countByReportedTypeAndReportedIdAndStatus(reportType, reportedId, status);
+    }
+    
+    /**
+     * 특정 컨텐츠의 총 신고 횟수 조회
+     */
+    @Transactional(readOnly = true)
+    public long getTotalReportCount(ReportType reportType, Long reportedId) {
+        return reportRepository.countByReportedTypeAndReportedId(reportType, reportedId);
+    }
 }

--- a/src/main/java/org/example/studiopick/domain/report/service/AutoHideService.java
+++ b/src/main/java/org/example/studiopick/domain/report/service/AutoHideService.java
@@ -1,0 +1,169 @@
+package org.example.studiopick.domain.report.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.studiopick.domain.artwork.Artwork;
+import org.example.studiopick.domain.class_entity.ClassEntity;
+import org.example.studiopick.domain.common.enums.ArtworkStatus;
+import org.example.studiopick.domain.common.enums.ClassStatus;
+import org.example.studiopick.domain.common.enums.ReportType;
+import org.example.studiopick.domain.common.enums.ReviewStatus;
+import org.example.studiopick.domain.review.Review;
+import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
+import org.example.studiopick.infrastructure.classes.ClassRepository;
+import org.example.studiopick.infrastructure.review.ReviewRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AutoHideService {
+    
+    private final ArtworkRepository artworkRepository;
+    private final ClassRepository classRepository;
+    private final ReviewRepository reviewRepository;
+    
+    /**
+     * 신고 횟수에 따라 자동으로 컨텐츠를 비공개 처리합니다.
+     * 
+     * @param reportType 신고 대상 타입
+     * @param reportedId 신고 대상 ID
+     * @return 비공개 처리 성공 여부
+     */
+    @Transactional
+    public boolean autoHideContent(ReportType reportType, Long reportedId) {
+        try {
+            switch (reportType) {
+                case ARTWORK:
+                    return hideArtwork(reportedId);
+                case CLASS:
+                    return hideClass(reportedId);
+                case REVIEW:
+                    return hideReview(reportedId);
+                default:
+                    log.warn("Unknown report type: {}", reportType);
+                    return false;
+            }
+        } catch (Exception e) {
+            log.error("Failed to auto hide content. Type: {}, ID: {}", reportType, reportedId, e);
+            return false;
+        }
+    }
+    
+    /**
+     * 작품을 신고 상태로 변경합니다.
+     */
+    private boolean hideArtwork(Long artworkId) {
+        return artworkRepository.findById(artworkId)
+                .map(artwork -> {
+                    artwork.changeStatus(ArtworkStatus.REPORTED);
+                    artworkRepository.save(artwork);
+                    log.info("Artwork {} has been auto-hidden due to reports", artworkId);
+                    return true;
+                })
+                .orElse(false);
+    }
+    
+    /**
+     * 클래스를 신고 상태로 변경합니다.
+     */
+    private boolean hideClass(Long classId) {
+        return classRepository.findById(classId)
+                .map(classEntity -> {
+                    classEntity.changeStatus(ClassStatus.REPORTED);
+                    classRepository.save(classEntity);
+                    log.info("Class {} has been auto-hidden due to reports", classId);
+                    return true;
+                })
+                .orElse(false);
+    }
+    
+    /**
+     * 리뷰를 신고 상태로 변경합니다.
+     */
+    private boolean hideReview(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .map(review -> {
+                    review.changeStatus(ReviewStatus.REPORTED);
+                    reviewRepository.save(review);
+                    log.info("Review {} has been auto-hidden due to reports", reviewId);
+                    return true;
+                })
+                .orElse(false);
+    }
+    
+    /**
+     * 신고로 인해 비공개된 컨텐츠를 복원합니다.
+     */
+    @Transactional
+    public boolean restoreContent(ReportType reportType, Long reportedId) {
+        try {
+            switch (reportType) {
+                case ARTWORK:
+                    return restoreArtwork(reportedId);
+                case CLASS:
+                    return restoreClass(reportedId);
+                case REVIEW:
+                    return restoreReview(reportedId);
+                default:
+                    log.warn("Unknown report type: {}", reportType);
+                    return false;
+            }
+        } catch (Exception e) {
+            log.error("Failed to restore content. Type: {}, ID: {}", reportType, reportedId, e);
+            return false;
+        }
+    }
+    
+    /**
+     * 작품을 공개 상태로 복원합니다.
+     */
+    private boolean restoreArtwork(Long artworkId) {
+        return artworkRepository.findById(artworkId)
+                .map(artwork -> {
+                    if (artwork.getStatus() == ArtworkStatus.REPORTED) {
+                        artwork.changeStatus(ArtworkStatus.PUBLIC);
+                        artworkRepository.save(artwork);
+                        log.info("Artwork {} has been restored", artworkId);
+                        return true;
+                    }
+                    return false;
+                })
+                .orElse(false);
+    }
+    
+    /**
+     * 클래스를 공개 상태로 복원합니다.
+     */
+    private boolean restoreClass(Long classId) {
+        return classRepository.findById(classId)
+                .map(classEntity -> {
+                    if (classEntity.getStatus() == ClassStatus.REPORTED) {
+                        classEntity.changeStatus(ClassStatus.OPEN);
+                        classRepository.save(classEntity);
+                        log.info("Class {} has been restored", classId);
+                        return true;
+                    }
+                    return false;
+                })
+                .orElse(false);
+    }
+    
+    /**
+     * 리뷰를 공개 상태로 복원합니다.
+     */
+    private boolean restoreReview(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .map(review -> {
+                    if (review.getStatus() == ReviewStatus.REPORTED) {
+                        review.changeStatus(ReviewStatus.VISIBLE);
+                        reviewRepository.save(review);
+                        log.info("Review {} has been restored", reviewId);
+                        return true;
+                    }
+                    return false;
+                })
+                .orElse(false);
+    }
+}

--- a/src/main/java/org/example/studiopick/domain/review/Review.java
+++ b/src/main/java/org/example/studiopick/domain/review/Review.java
@@ -87,6 +87,22 @@ public class Review extends BaseEntity {
         return this.status == ReviewStatus.DELETED;
     }
     
+    public void report() {
+        this.status = ReviewStatus.REPORTED;
+    }
+    
+    public void restore() {
+        this.status = ReviewStatus.VISIBLE;
+    }
+    
+    public boolean isReported() {
+        return this.status == ReviewStatus.REPORTED;
+    }
+    
+    public boolean isPubliclyVisible() {
+        return this.status == ReviewStatus.VISIBLE;
+    }
+    
     public boolean isValidRating() {
         return rating != null && rating >= 1 && rating <= 5;
     }

--- a/src/main/java/org/example/studiopick/infrastructure/review/ReviewRepository.java
+++ b/src/main/java/org/example/studiopick/infrastructure/review/ReviewRepository.java
@@ -1,0 +1,14 @@
+package org.example.studiopick.infrastructure.review;
+
+import org.example.studiopick.domain.review.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    List<Review> findByStudioId(Long studioId);
+    Optional<Review> findByIdAndUserId(Long id, Long userId);
+}

--- a/src/test/java/org/example/studiopick/domain/report/ReportServiceTest.java
+++ b/src/test/java/org/example/studiopick/domain/report/ReportServiceTest.java
@@ -1,0 +1,190 @@
+package org.example.studiopick.domain.report;
+
+import org.example.studiopick.domain.common.enums.ReportStatus;
+import org.example.studiopick.domain.common.enums.ReportType;
+import org.example.studiopick.domain.report.dto.ReportRequestDto;
+import org.example.studiopick.domain.report.dto.ReportResponseDto;
+import org.example.studiopick.domain.user.entity.User;
+import org.example.studiopick.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+    
+    @Mock
+    private UserRepository userRepository;
+    
+    @Mock
+    private org.example.studiopick.domain.report.service.AutoHideService autoHideService;
+    
+    @InjectMocks
+    private ReportService reportService;
+    
+    private User testUser;
+    private ReportRequestDto reportRequest;
+    
+    @BeforeEach
+    void setUp() {
+        testUser = mock(User.class);
+        reportRequest = new ReportRequestDto(
+            ReportType.ARTWORK,
+            1L,
+            "부적절한 콘텐츠입니다."
+        );
+    }
+    
+    @Test
+    void createReport_Success() {
+        // Given
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(reportRepository.existsByUserAndReportedTypeAndReportedId(any(), any(), any()))
+            .thenReturn(false);
+        when(reportRepository.countByReportedTypeAndReportedIdAndStatus(any(), any(), any()))
+            .thenReturn(1L); // 임계값 미만
+        when(reportRepository.save(any(Report.class))).thenAnswer(invocation -> {
+            Report report = invocation.getArgument(0);
+            // Mock ID 설정
+            when(report.getId()).thenReturn(1L);
+            return report;
+        });
+        
+        // When
+        ReportResponseDto response = reportService.createReport(userId, reportRequest);
+        
+        // Then
+        assertNotNull(response);
+        assertEquals("신고가 접수되었습니다.", response.message());
+        verify(reportRepository).save(any(Report.class));
+        verify(autoHideService, never()).autoHideContent(any(), any());
+    }
+    
+    @Test
+    void createReport_AlreadyReported() {
+        // Given
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(reportRepository.existsByUserAndReportedTypeAndReportedId(
+            testUser, reportRequest.reportedType(), reportRequest.reportedId()))
+            .thenReturn(true);
+        
+        // When & Then
+        IllegalStateException exception = assertThrows(IllegalStateException.class, 
+            () -> reportService.createReport(userId, reportRequest));
+        
+        assertEquals("이미 신고하셨습니다.", exception.getMessage());
+        verify(reportRepository, never()).save(any());
+    }
+    
+    @Test
+    void createReport_AutoHideTriggered() {
+        // Given
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.of(testUser));
+        when(reportRepository.existsByUserAndReportedTypeAndReportedId(any(), any(), any()))
+            .thenReturn(false);
+        when(reportRepository.countByReportedTypeAndReportedIdAndStatus(any(), any(), any()))
+            .thenReturn(3L); // 임계값 도달
+        when(autoHideService.autoHideContent(any(), any())).thenReturn(true);
+        
+        Report mockReport = mock(Report.class);
+        when(mockReport.getId()).thenReturn(1L);
+        when(reportRepository.save(any(Report.class))).thenReturn(mockReport);
+        
+        // When
+        ReportResponseDto response = reportService.createReport(userId, reportRequest);
+        
+        // Then
+        assertNotNull(response);
+        assertTrue(response.message().contains("자동으로 비공개 처리되었습니다"));
+        verify(autoHideService).autoHideContent(reportRequest.reportedType(), reportRequest.reportedId());
+        verify(mockReport).autoHide();
+    }
+    
+    @Test
+    void createReport_UserNotFound() {
+        // Given
+        Long userId = 1L;
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+        
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+            () -> reportService.createReport(userId, reportRequest));
+        
+        assertEquals("사용자 정보를 찾을 수 없습니다.", exception.getMessage());
+        verify(reportRepository, never()).save(any());
+    }
+    
+    @Test
+    void processReport_Success() {
+        // Given
+        Long reportId = 1L;
+        Long adminId = 2L;
+        String adminComment = "처리 완료";
+        
+        Report mockReport = mock(Report.class);
+        User mockAdmin = mock(User.class);
+        
+        when(reportRepository.findById(reportId)).thenReturn(Optional.of(mockReport));
+        when(userRepository.findById(adminId)).thenReturn(Optional.of(mockAdmin));
+        when(mockReport.getReportedType()).thenReturn(ReportType.ARTWORK);
+        when(mockReport.getReportedId()).thenReturn(1L);
+        
+        // When
+        reportService.processReport(reportId, adminId, ReportStatus.RESTORED, adminComment);
+        
+        // Then
+        verify(mockReport).restore(mockAdmin, adminComment);
+        verify(autoHideService).restoreContent(ReportType.ARTWORK, 1L);
+        verify(reportRepository).save(mockReport);
+    }
+    
+    @Test
+    void getReportCount_Success() {
+        // Given
+        ReportType reportType = ReportType.ARTWORK;
+        Long reportedId = 1L;
+        ReportStatus status = ReportStatus.PENDING;
+        long expectedCount = 5L;
+        
+        when(reportRepository.countByReportedTypeAndReportedIdAndStatus(reportType, reportedId, status))
+            .thenReturn(expectedCount);
+        
+        // When
+        long actualCount = reportService.getReportCount(reportType, reportedId, status);
+        
+        // Then
+        assertEquals(expectedCount, actualCount);
+    }
+    
+    @Test
+    void getTotalReportCount_Success() {
+        // Given
+        ReportType reportType = ReportType.ARTWORK;
+        Long reportedId = 1L;
+        long expectedCount = 10L;
+        
+        when(reportRepository.countByReportedTypeAndReportedId(reportType, reportedId))
+            .thenReturn(expectedCount);
+        
+        // When
+        long actualCount = reportService.getTotalReportCount(reportType, reportedId);
+        
+        // Then
+        assertEquals(expectedCount, actualCount);
+    }
+}

--- a/src/test/java/org/example/studiopick/domain/report/service/AutoHideServiceTest.java
+++ b/src/test/java/org/example/studiopick/domain/report/service/AutoHideServiceTest.java
@@ -1,0 +1,145 @@
+package org.example.studiopick.domain.report.service;
+
+import org.example.studiopick.domain.artwork.Artwork;
+import org.example.studiopick.domain.class_entity.ClassEntity;
+import org.example.studiopick.domain.common.enums.ArtworkStatus;
+import org.example.studiopick.domain.common.enums.ClassStatus;
+import org.example.studiopick.domain.common.enums.ReportType;
+import org.example.studiopick.domain.common.enums.ReviewStatus;
+import org.example.studiopick.domain.review.Review;
+import org.example.studiopick.infrastructure.artwork.ArtworkRepository;
+import org.example.studiopick.infrastructure.classes.ClassRepository;
+import org.example.studiopick.infrastructure.review.ReviewRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AutoHideServiceTest {
+
+    @Mock
+    private ArtworkRepository artworkRepository;
+    
+    @Mock
+    private ClassRepository classRepository;
+    
+    @Mock
+    private ReviewRepository reviewRepository;
+    
+    @InjectMocks
+    private AutoHideService autoHideService;
+    
+    @Test
+    void autoHideArtwork_Success() {
+        // Given
+        Long artworkId = 1L;
+        Artwork artwork = mock(Artwork.class);
+        
+        when(artworkRepository.findById(artworkId)).thenReturn(Optional.of(artwork));
+        when(artworkRepository.save(any(Artwork.class))).thenReturn(artwork);
+        
+        // When
+        boolean result = autoHideService.autoHideContent(ReportType.ARTWORK, artworkId);
+        
+        // Then
+        assertTrue(result);
+        verify(artwork).changeStatus(ArtworkStatus.REPORTED);
+        verify(artworkRepository).save(artwork);
+    }
+    
+    @Test
+    void autoHideArtwork_NotFound() {
+        // Given
+        Long artworkId = 1L;
+        when(artworkRepository.findById(artworkId)).thenReturn(Optional.empty());
+        
+        // When
+        boolean result = autoHideService.autoHideContent(ReportType.ARTWORK, artworkId);
+        
+        // Then
+        assertFalse(result);
+        verify(artworkRepository, never()).save(any());
+    }
+    
+    @Test
+    void autoHideClass_Success() {
+        // Given
+        Long classId = 1L;
+        ClassEntity classEntity = mock(ClassEntity.class);
+        
+        when(classRepository.findById(classId)).thenReturn(Optional.of(classEntity));
+        when(classRepository.save(any(ClassEntity.class))).thenReturn(classEntity);
+        
+        // When
+        boolean result = autoHideService.autoHideContent(ReportType.CLASS, classId);
+        
+        // Then
+        assertTrue(result);
+        verify(classEntity).changeStatus(ClassStatus.REPORTED);
+        verify(classRepository).save(classEntity);
+    }
+    
+    @Test
+    void autoHideReview_Success() {
+        // Given
+        Long reviewId = 1L;
+        Review review = mock(Review.class);
+        
+        when(reviewRepository.findById(reviewId)).thenReturn(Optional.of(review));
+        when(reviewRepository.save(any(Review.class))).thenReturn(review);
+        
+        // When
+        boolean result = autoHideService.autoHideContent(ReportType.REVIEW, reviewId);
+        
+        // Then
+        assertTrue(result);
+        verify(review).changeStatus(ReviewStatus.REPORTED);
+        verify(reviewRepository).save(review);
+    }
+    
+    @Test
+    void restoreArtwork_Success() {
+        // Given
+        Long artworkId = 1L;
+        Artwork artwork = mock(Artwork.class);
+        
+        when(artworkRepository.findById(artworkId)).thenReturn(Optional.of(artwork));
+        when(artwork.getStatus()).thenReturn(ArtworkStatus.REPORTED);
+        when(artworkRepository.save(any(Artwork.class))).thenReturn(artwork);
+        
+        // When
+        boolean result = autoHideService.restoreContent(ReportType.ARTWORK, artworkId);
+        
+        // Then
+        assertTrue(result);
+        verify(artwork).changeStatus(ArtworkStatus.PUBLIC);
+        verify(artworkRepository).save(artwork);
+    }
+    
+    @Test
+    void restoreArtwork_NotReported() {
+        // Given
+        Long artworkId = 1L;
+        Artwork artwork = mock(Artwork.class);
+        
+        when(artworkRepository.findById(artworkId)).thenReturn(Optional.of(artwork));
+        when(artwork.getStatus()).thenReturn(ArtworkStatus.PUBLIC); // 이미 공개 상태
+        
+        // When
+        boolean result = autoHideService.restoreContent(ReportType.ARTWORK, artworkId);
+        
+        // Then
+        assertFalse(result);
+        verify(artwork, never()).changeStatus(any());
+        verify(artworkRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
tudio-Pick 신고 시스템 (Report System)
📋 개요
Studio-Pick 플랫폼의 사용자 신고 처리 시스템입니다. 사용자가 부적절한 콘텐츠를 신고할 수 있고, 일정 수준의 신고가 누적되면 자동으로 비공개 처리되는 기능을 제공합니다.
🚀 주요 기능
✅ 구현 완료된 기능
1. 기본 신고 기능

신고 등록: 사용자가 Artwork, Class, Review에 대해 신고 가능
중복 신고 방지: 같은 사용자가 같은 콘텐츠를 중복 신고할 수 없음
신고 사유 입력: 신고 시 구체적인 사유 기록

2. 자동 비공개 처리 (🆕 구현 완료)

임계값 기반 처리: 기본 3회 신고 시 자동 비공개
실시간 상태 변경: 신고 임계값 도달 시 즉시 콘텐츠 상태 변경
로깅 시스템: 모든 자동 처리 과정 로그 기록

3. 콘텐츠별 상태 관리

Artwork: PUBLIC → REPORTED 상태 변경
Class: OPEN → REPORTED 상태 변경
Review: VISIBLE → REPORTED 상태 변경

4. 복원 기능

관리자 복원: 부당한 신고로 판단 시 콘텐츠 복원 가능
자동 복원: 원래 상태로 되돌리기

🏗️ 시스템 구조
도메인 모델
Report (신고)
├── reportedType: ReportType (ARTWORK, CLASS, REVIEW)
├── reportedId: Long (신고 대상 ID)
├── user: User (신고자)
├── reason: String (신고 사유)
├── status: ReportStatus (PENDING, AUTO_HIDDEN, REVIEWED, RESTORED, DELETED)
├── admin: User (처리 관리자)
├── adminComment: String (관리자 코멘트)
└── processedAt: LocalDateTime (처리 시간)
서비스 계층
ReportService
├── createReport() - 신고 등록
├── processReport() - 관리자 신고 처리
├── getReportCount() - 신고 횟수 조회
└── getTotalReportCount() - 총 신고 횟수 조회

AutoHideService
├── autoHideContent() - 자동 비공개 처리
└── restoreContent() - 콘텐츠 복원
⚙️ 설정
application.yml 설정
yamlapp:
  report:
    # 자동 비공개 처리를 위한 신고 임계값
    auto-hide-threshold: 3
    
    # 신고 관련 알림 설정
    notification:
      enabled: true
      admin-email: admin@studiopick.com
      
    # 자동 처리 설정
    auto-processing:
      enabled: true
      auto-restore-enabled: false

🔄 자동 비공개 처리 플로우

신고 접수: 사용자가 신고 등록
중복 확인: 동일 사용자의 중복 신고 방지
신고 저장: DB에 신고 정보 저장
임계값 확인: 해당 콘텐츠의 신고 횟수 확인
자동 처리: 임계값 도달 시 자동 비공개 처리

Artwork → REPORTED 상태 변경
Class → REPORTED 상태 변경
Review → REPORTED 상태 변경



📊 상태 관리
ReportStatus

PENDING: 처리 대기 중
AUTO_HIDDEN: 자동 비공개 처리됨
REVIEWED: 관리자가 검토 완료
RESTORED: 복원 처리됨
DELETED: 삭제 처리됨

ReportType

ARTWORK: 작품 신고
CLASS: 클래스 신고
REVIEW: 리뷰 신고
