### PR TITLE
정산 내역 조회 및 출금 요청 처리 + 수수료 계산 및 세금처리  STUDIO016

### DIFF
--- a/src/main/java/org/example/studiopick/application/favorite/FavoriteService.java
+++ b/src/main/java/org/example/studiopick/application/favorite/FavoriteService.java
@@ -5,7 +5,7 @@ import org.example.studiopick.common.favorite.FavoriteCreateDto;
 import org.example.studiopick.common.favorite.FavoriteResponseDto;
 import org.example.studiopick.domain.common.enums.FavoriteType;
 import org.example.studiopick.domain.favorite.Favorite;
-import org.example.studiopick.domain.payment.FavoriteRepository;
+import org.example.studiopick.domain.favorite.FavoriteRepository;
 import org.example.studiopick.domain.studio.Studio;
 import org.example.studiopick.domain.studio.repository.StudioRepository;
 import org.example.studiopick.domain.user.entity.User;

--- a/src/main/java/org/example/studiopick/application/payment/SettlementService.java
+++ b/src/main/java/org/example/studiopick/application/payment/SettlementService.java
@@ -1,0 +1,88 @@
+package org.example.studiopick.application.payment;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.payment.dto.SettlementResponseDto;
+import org.example.studiopick.domain.payment.Payment;
+import org.example.studiopick.domain.payment.Settlement;
+import org.example.studiopick.domain.payment.SettlementRepository;
+import org.example.studiopick.domain.common.enums.SettlementStatus;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SettlementService {
+
+    private final SettlementRepository settlementRepository;
+
+    public List<SettlementResponseDto> getSettlementsByStudio(Long studioId) {
+        return settlementRepository.findByStudioId(studioId).stream()
+                .map(s -> SettlementResponseDto.builder()
+                        .settlementId(s.getId())
+                        .paymentId(s.getPayment().getId())
+                        .totalAmount(s.getTotalAmount())
+                        .platformFee(s.getPlatformFee())
+                        .payoutAmount(s.getPayoutAmount())
+                        .taxAmount(s.getTaxAmount())
+                        .status(s.getSettlementStatus().name())
+                        .settledAt(s.getSettledAt())
+                        .build())
+                .collect(Collectors.toList());
+    }
+
+    @Transactional
+    public void withdrawSettlement(Long settlementId) {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new IllegalArgumentException("정산 내역을 찾을 수 없습니다."));
+
+        if (settlement.isPaid() || settlement.isOnHold()) {
+            throw new IllegalStateException("이미 출금되었거나 요청 중인 정산입니다.");
+        }
+
+        settlement.hold();
+        settlementRepository.save(settlement);
+    }
+
+    @Transactional
+    public void createSettlement(Payment payment) {
+        var studio = payment.getReservation().getStudio();
+        var commission = studio.getCommission();
+        if (commission == null) throw new IllegalStateException("수수료 정보가 없습니다");
+
+        BigDecimal totalAmount = payment.getAmount();
+        BigDecimal commissionRate = commission.getCommissionRate();
+        BigDecimal platformFee = totalAmount.multiply(commissionRate).divide(BigDecimal.valueOf(100));
+        BigDecimal payoutAmount = totalAmount.subtract(platformFee);
+
+        BigDecimal taxRate = BigDecimal.valueOf(3.3); // 세금율 3.3%
+        BigDecimal taxAmount = payoutAmount.multiply(taxRate).divide(BigDecimal.valueOf(100));
+
+        Settlement settlement = Settlement.builder()
+                .studio(studio)
+                .payment(payment)
+                .totalAmount(totalAmount)
+                .platformFee(platformFee)
+                .payoutAmount(payoutAmount)
+                .taxAmount(taxAmount)
+                .settlementStatus(SettlementStatus.PENDING)
+                .build();
+
+        settlementRepository.save(settlement);
+    }
+
+    @Transactional
+    public void approveSettlement(Long settlementId) {
+        Settlement settlement = settlementRepository.findById(settlementId)
+                .orElseThrow(() -> new IllegalArgumentException("정산 내역을 찾을 수 없습니다."));
+
+        if (!settlement.isOnHold()) {
+            throw new IllegalStateException("HOLD 상태인 정산만 승인할 수 있습니다.");
+        }
+
+        settlement.markAsPaid(); // 상태: PAID, 시간: now()
+    }
+}

--- a/src/main/java/org/example/studiopick/application/payment/dto/SettlementResponseDto.java
+++ b/src/main/java/org/example/studiopick/application/payment/dto/SettlementResponseDto.java
@@ -1,0 +1,20 @@
+package org.example.studiopick.application.payment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SettlementResponseDto {
+    private Long settlementId;
+    private Long paymentId;
+    private BigDecimal totalAmount;
+    private BigDecimal platformFee;
+    private BigDecimal payoutAmount;
+    private BigDecimal taxAmount;
+    private String status;
+    private LocalDateTime settledAt;
+}

--- a/src/main/java/org/example/studiopick/application/payment/dto/SettlementWithdrawRequestDto.java
+++ b/src/main/java/org/example/studiopick/application/payment/dto/SettlementWithdrawRequestDto.java
@@ -1,0 +1,10 @@
+package org.example.studiopick.application.payment.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SettlementWithdrawRequestDto {
+    private String memo; // 선택: 출금 요청 메모나 사유 등 프론트에서 받는 경우
+}

--- a/src/main/java/org/example/studiopick/common/enums/SettlementStatus.java
+++ b/src/main/java/org/example/studiopick/common/enums/SettlementStatus.java
@@ -1,0 +1,4 @@
+package org.example.studiopick.common.enums;
+
+public class SettlementStatus {
+}

--- a/src/main/java/org/example/studiopick/domain/favorite/FavoriteRepository.java
+++ b/src/main/java/org/example/studiopick/domain/favorite/FavoriteRepository.java
@@ -1,7 +1,6 @@
-package org.example.studiopick.domain.payment;
+package org.example.studiopick.domain.favorite;
 
 import org.example.studiopick.domain.common.enums.FavoriteType;
-import org.example.studiopick.domain.favorite.Favorite;
 import org.example.studiopick.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;

--- a/src/main/java/org/example/studiopick/domain/payment/Settlement.java
+++ b/src/main/java/org/example/studiopick/domain/payment/Settlement.java
@@ -17,69 +17,78 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Settlement extends BaseEntity {
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "studio_id")
     private Studio studio;
-    
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "payment_id")
     private Payment payment;
-    
+
     @Column(name = "total_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal totalAmount;
-    
+
     @Column(name = "platform_fee", nullable = false, precision = 10, scale = 2)
     private BigDecimal platformFee;
-    
+
     @Column(name = "payout_amount", nullable = false, precision = 10, scale = 2)
     private BigDecimal payoutAmount;
-    
+
+    // ✅ taxAmount 필드
+    @Column(name = "tax_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal taxAmount;
+
     @Enumerated(EnumType.STRING)
     @Column(name = "settlement_status", nullable = false)
     private SettlementStatus settlementStatus = SettlementStatus.PENDING;
-    
+
     @Column(name = "settled_at")
     private LocalDateTime settledAt;
-    
+
+    // ✅ 최종 Builder 생성자
     @Builder
-    public Settlement(Studio studio, Payment payment, BigDecimal totalAmount, 
-                     BigDecimal platformFee, BigDecimal payoutAmount, SettlementStatus settlementStatus) {
+    public Settlement(Studio studio, Payment payment, BigDecimal totalAmount,
+                      BigDecimal platformFee, BigDecimal payoutAmount, BigDecimal taxAmount,
+                      SettlementStatus settlementStatus) {
         this.studio = studio;
         this.payment = payment;
         this.totalAmount = totalAmount;
         this.platformFee = platformFee;
         this.payoutAmount = payoutAmount;
+        this.taxAmount = taxAmount;
         this.settlementStatus = settlementStatus != null ? settlementStatus : SettlementStatus.PENDING;
     }
-    
-    public void updateAmounts(BigDecimal totalAmount, BigDecimal platformFee, BigDecimal payoutAmount) {
+
+    // ✅ 최종 updateAmounts 메서드
+    public void updateAmounts(BigDecimal totalAmount, BigDecimal platformFee, BigDecimal payoutAmount, BigDecimal taxAmount) {
         this.totalAmount = totalAmount;
         this.platformFee = platformFee;
         this.payoutAmount = payoutAmount;
+        this.taxAmount = taxAmount;
     }
-    
+
     public void changeStatus(SettlementStatus status) {
         this.settlementStatus = status;
     }
-    
+
     public void markAsPaid() {
         this.settlementStatus = SettlementStatus.PAID;
         this.settledAt = LocalDateTime.now();
     }
-    
+
     public void hold() {
         this.settlementStatus = SettlementStatus.HOLD;
     }
-    
+
     public boolean isPaid() {
         return this.settlementStatus == SettlementStatus.PAID;
     }
-    
+
     public boolean isOnHold() {
         return this.settlementStatus == SettlementStatus.HOLD;
     }
-    
+
     public boolean isPending() {
         return this.settlementStatus == SettlementStatus.PENDING;
     }

--- a/src/main/java/org/example/studiopick/domain/payment/SettlementRepository.java
+++ b/src/main/java/org/example/studiopick/domain/payment/SettlementRepository.java
@@ -1,0 +1,9 @@
+package org.example.studiopick.domain.payment;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SettlementRepository extends JpaRepository<Settlement, Long> {
+    List<Settlement> findByStudioId(Long studioId);
+}

--- a/src/main/java/org/example/studiopick/web/admin/AdminSettlementController.java
+++ b/src/main/java/org/example/studiopick/web/admin/AdminSettlementController.java
@@ -1,0 +1,24 @@
+package org.example.studiopick.web.admin;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.payment.SettlementService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/settlements")
+@Tag(name = "관리자 정산 API", description = "관리자 전용 정산 관리 기능")
+public class AdminSettlementController {
+
+    private final SettlementService settlementService;
+
+    @PostMapping("/{settlementId}/approve")
+    @Operation(summary = "정산 승인", description = "출금 요청(HOLD 상태)된 정산을 관리자 권한으로 승인(PAID) 처리합니다.")
+    public ResponseEntity<String> approveSettlement(@PathVariable Long settlementId) {
+        settlementService.approveSettlement(settlementId);
+        return ResponseEntity.ok("정산이 승인되었습니다.");
+    }
+}

--- a/src/main/java/org/example/studiopick/web/studio/SettlementController.java
+++ b/src/main/java/org/example/studiopick/web/studio/SettlementController.java
@@ -1,0 +1,38 @@
+package org.example.studiopick.web.studio;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.example.studiopick.application.payment.SettlementService;
+import org.example.studiopick.application.payment.dto.SettlementResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studios/{studioId}/settlements")
+@Tag(name = "정산 API", description = "스튜디오 정산 내역 및 출금 요청 관련 API")
+public class SettlementController {
+
+    private final SettlementService settlementService;
+
+    @Operation(summary = "정산 내역 조회", description = "스튜디오 ID를 기준으로 정산 내역을 조회합니다.")
+    @GetMapping
+    public ResponseEntity<List<SettlementResponseDto>> getSettlements(
+            @PathVariable Long studioId
+    ) {
+        List<SettlementResponseDto> result = settlementService.getSettlementsByStudio(studioId);
+        return ResponseEntity.ok(result);
+    }
+
+    @Operation(summary = "정산 출금 요청", description = "해당 정산 ID에 대해 출금 요청을 진행합니다. (상태: HOLD)")
+    @PostMapping("/{settlementId}/withdraw")
+    public ResponseEntity<String> requestWithdraw(
+            @PathVariable Long settlementId
+    ) {
+        settlementService.withdrawSettlement(settlementId);
+        return ResponseEntity.ok("출금 요청이 완료되었습니다.");
+    }
+}


### PR DESCRIPTION
✅ 작업 개요
STUDIO016 - 스튜디오 정산 기능 구현
정산 내역 조회 + 출금 요청 처리 + 수수료 및 세금 계산 로직 추가

🔧 주요 구현 내용
Settlement 도메인에 taxAmount 필드 및 계산 로직 추가

SettlementService

정산 생성 시 수수료(platformFee) 및 세금(taxAmount) 자동 계산

출금 요청 시 HOLD 상태로 변경

관리자 승인 시 PAID 상태로 정산 완료 처리

사용자용 API

GET /api/studios/{studioId}/settlements: 정산 내역 조회

POST /api/studios/{studioId}/settlements/{settlementId}/withdraw: 출금 요청

관리자용 API

POST /api/admin/settlements/{settlementId}/approve: 출금 승인

📝 비고
DB에 tax_amount 컬럼이 없다면 아래 SQL 추가 필요:

sql
복사
편집
ALTER TABLE "Settlement" ADD COLUMN tax_amount DECIMAL(10,2) NOT NULL;
ddl-auto: update 설정 시 자동 반영됨

Swagger 테스트는 settlementId 입력 시 정상 동작 확인됨